### PR TITLE
Add a `cargo xtask' alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"


### PR DESCRIPTION
No functional changes, merely lets the user type `cargo xtask' instead of `cargo --package xtask --'.