### PR TITLE
Update README and battery stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,48 @@
 # Hafnium EC Service in Rust
 
 ## Overview
-This is sample implementation of the EC service which runs under a separate SP partition in Hafnium.
-
-It is written in Rust and has dependencies on FF-A, MU UEFI, Hafnium and TFA
+This is a sample implementation of the EC service which runs under a dedicated secure partition in Hafnium.
+It is written in Rust and has dependencies on FF-A, MU UEFI, Hafnium and TFA.
 
 ## Feature Status
-The following components are available within this crate.
+The following components are available within this crate:
 ```
-xtask       - Wrapper around cargo process for bare metal compilation
-ec-sp       - EC secure partition souce code, memory map and build files
-build.rs    - Creates memory map files from input memory.x
-memory.x    - Memory map for linking output binaries
-start.s     - Initial entry point in assembly jumps to sp_main
-exception.s - Exception handling code
-main.rs     - Main entry point for SP
-panic.rs    - Panic handling code for RUST panic
-fw_mgmt     - Implements the EC firmware management service
-notify      - Implements the EC notification service
-thermal     - Implements the EC thermal service
+ec-service-lib - Common code used in implementation of EC SP
+platform       - Contains target specific code for supported platforms
 ```
 
 ## Customizations
-Update memory.x to match the memory map from your dts file
+Update memory map definitions in platforms/plat/linker folder to match the definition from your dts config file.
 ```
 	load-address = <0x0 0x20400000>;
 	entrypoint-offset = <0x10000>;
 	image-size = <0x0 0x40000>;
 ```
-From memory.x this needs to match
+
 ```
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x20410000, LENGTH = 0x30000
-    DRAM (rwx) : ORIGIN = 0x20440000, LENGTH = 0x100000
+	image : ORIGIN = 0x20410000, LENGTH = 2M
+	rxtx_buf : ORIGIN = 0x100600A0000, LENGTH = 8K
+	smem : ORIGIN = 0x10060000000, LENGTH = 8K
 }
 ```
 
 ## Build Instructions
-`cargo xtask build`
+From the root folder you can build all platforms using
+`cargo build`
+
+To build for aarch64 target use
+`cargo build --target=aarch64-unknown-none`
+
+To convert the output ELF to binary run
+`cargo objcopy --target=aarch64-unknown-none -- -O binary output.bin`
 
 ## Build Validation
-Before submission the following commands should all be validated to make sure there files are correctly formatted any only valid crates and features are used.
+Before submission the following commands should all be validated.
 ```
+cargo build
+cargo build --target=aarch64-unknown-none
 cargo +nightly fmt
 cargo +nightly clippy
 cargo hack --feature-powerset check

--- a/ec-service-lib/src/battery/mod.rs
+++ b/ec-service-lib/src/battery/mod.rs
@@ -1,0 +1,47 @@
+use ffa::msg::FfaMsg;
+use ffa::{FfaError, FfaFunctionId};
+
+pub type Result<T> = core::result::Result<T, ffa::FfaError>;
+
+#[derive(Default)]
+struct GenericRsp {
+    _status: i64,
+}
+
+#[derive(Default)]
+pub struct Battery {}
+
+impl Battery {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn ffa_msg_send_direct_req2(&self, msg: &FfaMsg) -> Result<FfaMsg> {
+        let cmd = msg.extract_u8_at_index(0);
+        println!("Received Battery command 0x{:x}", cmd);
+
+        // Create new generic rsp packet swap destination and source
+        let mut rsp = FfaMsg {
+            function_id: FfaFunctionId::FfaMsgSendDirectResp2.into(),
+            source_id: msg.destination_id,
+            destination_id: msg.source_id,
+            uuid: msg.uuid,
+            ..Default::default()
+        };
+        rsp.struct_to_args64(&GenericRsp { _status: 0x0 });
+        Ok(rsp)
+    }
+
+    // Handles messages sent to the EC Firmware management service
+    pub(crate) fn exec(self, msg: &FfaMsg) -> Result<FfaMsg> {
+        let id = FfaFunctionId::from(msg.function_id);
+
+        match id {
+            FfaFunctionId::FfaMsgSendDirectReq2 => self.ffa_msg_send_direct_req2(msg),
+            _ => {
+                println!("Unhandled FfaFunctionId in Battery: {:?}", id);
+                Err(FfaError::InvalidParameters)
+            }
+        }
+    }
+}

--- a/ec-service-lib/src/fw_mgmt/mod.rs
+++ b/ec-service-lib/src/fw_mgmt/mod.rs
@@ -3,8 +3,7 @@ use ffa::memory::FfaMemory;
 use ffa::msg::FfaMsg;
 #[cfg(debug_assertions)]
 use ffa::notify::FfaNotify;
-use ffa::FfaError;
-use ffa::FfaFunctionId;
+use ffa::{FfaError, FfaFunctionId};
 
 pub type Result<T> = core::result::Result<T, ffa::FfaError>;
 

--- a/ec-service-lib/src/lib.rs
+++ b/ec-service-lib/src/lib.rs
@@ -6,10 +6,10 @@ extern crate ffa;
 
 use ffa::msg::FfaMsg;
 use ffa::rxtx::FfaRxTxMsg;
-use ffa::Ffa;
-use ffa::FfaError;
+use ffa::{Ffa, FfaError};
 use uuid::{uuid, Uuid};
 
+mod battery;
 mod fw_mgmt;
 mod notify;
 mod thermal;
@@ -87,7 +87,10 @@ impl HafEcService {
                 ntfy.exec(msg)
             }
             UUID_EC_SVC_POWER => unimplemented!(),
-            UUID_EC_SVC_BATTERY => unimplemented!(),
+            UUID_EC_SVC_BATTERY => {
+                let bat = battery::Battery::new();
+                bat.exec(msg)
+            }
             UUID_EC_SVC_THERMAL => {
                 let thm = thermal::ThmMgmt::new();
                 thm.exec(msg)

--- a/ec-service-lib/src/notify/mod.rs
+++ b/ec-service-lib/src/notify/mod.rs
@@ -1,7 +1,5 @@
 use ffa::msg::FfaMsg;
-use ffa::FfaError;
-use ffa::FfaFunctionId;
-
+use ffa::{FfaError, FfaFunctionId};
 use uuid::Uuid;
 
 pub type Result<T> = core::result::Result<T, ffa::FfaError>;

--- a/ec-service-lib/src/thermal/mod.rs
+++ b/ec-service-lib/src/thermal/mod.rs
@@ -1,9 +1,7 @@
 use ffa::msg::FfaMsg;
 use ffa::yld::FfaYield;
-use ffa::FfaError;
-use ffa::FfaFunctionId;
-use uuid::Builder;
-use uuid::Uuid;
+use ffa::{FfaError, FfaFunctionId};
+use uuid::{Builder, Uuid};
 
 pub type Result<T> = core::result::Result<T, ffa::FfaError>;
 

--- a/platform/ihv1-sp/README.md
+++ b/platform/ihv1-sp/README.md
@@ -1,6 +1,6 @@
 # IHV Embedded Controller Secure Partition
 
-An example secure partition reference for independet hardware vendor that uses haf-ec-service.
+An example secure partition reference for independent hardware vendors.
 
 - `aarch64-paging` for page table management.
 - `aarch64-rt` for the entry point and exception handling.
@@ -8,6 +8,6 @@ An example secure partition reference for independet hardware vendor that uses h
 ## Building
 
 ```
-cargo build
+cargo build --target=aarch64-unknown-none
 cargo objcopy -- -O binary target/aarch64-unknown-none/debug/ihv1-ec-sp.bin
 ```

--- a/platform/qemu-sp/README.md
+++ b/platform/qemu-sp/README.md
@@ -1,6 +1,6 @@
 # QEMU Embedded Controller Secure Partition
 
-An implementation of embedded controller secure partition for QEmu haf-ec-service.
+An implementation of embedded controller secure partition for QEMU haf-ec-service.
 
 - `aarch64-paging` for page table management.
 - `aarch64-rt` for the entry point and exception handling.
@@ -8,6 +8,6 @@ An implementation of embedded controller secure partition for QEmu haf-ec-servic
 ## Building
 
 ```
-cargo build
+cargo build --target=aarch64-unknown-none
 cargo objcopy -- -O binary target/aarch64-unknown-none/debug/qemu-ec-sp.bin
 ```

--- a/platform/qemu-sp/src/baremetal/panic.rs
+++ b/platform/qemu-sp/src/baremetal/panic.rs
@@ -1,8 +1,9 @@
 //! A panic handler that infinitely waits.
 extern crate ffa; // Remove this after moving to logger
 
-use aarch64_cpu::asm;
 use core::panic::PanicInfo;
+
+use aarch64_cpu::asm;
 use ffa::println;
 
 /// Stop immediately if called a second time.


### PR DESCRIPTION
Battery is required for OS to boot when _BST is defined so add default handler of battery requests.

Updated README files to match new structure.