### PR TITLE
Use trait to define services, use that for message dispatching

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "rust-analyzer.check.allTargets": false,
+    "rust-analyzer.cargo.target": "aarch64-unknown-none",
     "rust-analyzer.cargo.features": "all"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [workspace.dependencies]
 ffa = { git = "https://github.com/OpenDevicePartnership/ffa", rev = "1f6ef264" }
-haf_ec_service = { path = "ec-service-lib" }
+ec-service-lib = { path = "ec-service-lib" }
 aarch64-rt = { version = "0.1.0", default-features = false, features = [
     "el1",
     "exceptions",

--- a/ec-service-lib/Cargo.toml
+++ b/ec-service-lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "haf_ec_service"
+name = "ec-service-lib"
 categories = ["embedded", "no-std"]
 version = "0.1.0"
 edition = "2021"

--- a/ec-service-lib/src/service.rs
+++ b/ec-service-lib/src/service.rs
@@ -1,0 +1,45 @@
+use ffa::{msg::FfaMsg, FfaError, FfaFunctionId};
+use uuid::Uuid;
+
+pub type Result<T> = core::result::Result<T, FfaError>;
+
+pub trait Service {
+    fn service_name(&self) -> &'static str;
+    fn service_uuid(&self) -> &'static Uuid;
+
+    fn ffa_msg_send_direct_req2(&mut self, msg: &FfaMsg) -> Result<FfaMsg> {
+        self.handler_unimplemented(msg)
+    }
+}
+
+pub(crate) trait ServiceImpl: Service {
+    fn exec(&mut self, msg: &FfaMsg) -> Result<FfaMsg> {
+        let id = FfaFunctionId::from(msg.function_id);
+
+        match id {
+            FfaFunctionId::FfaMsgSendDirectReq2 => self.ffa_msg_send_direct_req2(msg),
+            _ => {
+                println!("FfaFunctionId has no handler in {}: {:?}", self.service_name(), id);
+                Err(FfaError::InvalidParameters)
+            }
+        }
+    }
+
+    fn handler_unimplemented(&self, msg: &FfaMsg) -> Result<FfaMsg> {
+        println!(
+            "FfaFunctionId is unimplemented in {}: {:?}",
+            self.service_name(),
+            msg.function_id
+        );
+        Err(FfaError::InvalidParameters)
+    }
+}
+
+impl<T: Service + ?Sized> ServiceImpl for T {}
+
+#[macro_export]
+macro_rules! service_array {
+    ($($service:expr),*) => {
+        [$(core::cell::RefCell::new(&mut $service as &mut dyn $crate::Service)),*]
+    };
+}

--- a/ec-service-lib/src/services/mod.rs
+++ b/ec-service-lib/src/services/mod.rs
@@ -1,0 +1,9 @@
+mod battery;
+mod fw_mgmt;
+mod notify;
+mod thermal;
+
+pub use battery::Battery;
+pub use fw_mgmt::FwMgmt;
+pub use notify::Notify;
+pub use thermal::Thermal;

--- a/platform/ihv1-sp/Cargo.toml
+++ b/platform/ihv1-sp/Cargo.toml
@@ -20,7 +20,7 @@ aarch64-cpu.workspace = true
 
 [dependencies]
 ffa.workspace = true
-haf_ec_service.workspace = true
+ec-service-lib.workspace = true
 aarch64-rt = { workspace = true, optional = true }
 aarch64-paging = { workspace = true, optional = true }
 aarch64-cpu = { workspace = true, optional = true }

--- a/platform/ihv1-sp/src/baremetal/mod.rs
+++ b/platform/ihv1-sp/src/baremetal/mod.rs
@@ -5,12 +5,22 @@ use aarch64_rt::entry;
 
 entry!(main);
 fn main(_arg0: u64, _arg1: u64, _arg2: u64, _arg3: u64) -> ! {
-    // Program VBAR_EL1 to our exception handlers
-    // Call into the haf-ec-service sp_main
-    let service = haf_ec_service::HafEcService {
+    let mut thermal = ec_service_lib::services::Thermal::new();
+    let mut battery = ec_service_lib::services::Battery::new();
+    let mut fw_mgmt = ec_service_lib::services::FwMgmt::new();
+    let mut notify = ec_service_lib::services::Notify::new();
+
+    let services = ec_service_lib::service_array![thermal, battery, fw_mgmt, notify];
+
+    let service = ec_service_lib::HafEcService {
         rx_buffer_base: 0,
         tx_buffer_base: 0,
         rxtx_page_count: 0,
+        services: services.as_ref(),
     };
+
+    // Program VBAR_EL1 to our exception handlers
+    // Call into the haf-ec-service sp_main
+
     service.sp_main();
 }

--- a/platform/qemu-sp/Cargo.toml
+++ b/platform/qemu-sp/Cargo.toml
@@ -20,7 +20,7 @@ aarch64-cpu.workspace = true
 
 [dependencies]
 ffa.workspace = true
-haf_ec_service.workspace = true
+ec-service-lib.workspace = true
 aarch64-rt = { workspace = true, optional = true }
 aarch64-paging = { workspace = true, optional = true }
 aarch64-cpu = { workspace = true, optional = true }

--- a/platform/qemu-sp/src/baremetal/mod.rs
+++ b/platform/qemu-sp/src/baremetal/mod.rs
@@ -5,12 +5,20 @@ use aarch64_rt::entry;
 
 entry!(main);
 fn main(_arg0: u64, _arg1: u64, _arg2: u64, _arg3: u64) -> ! {
+    let mut thermal = ec_service_lib::services::Thermal::new();
+    let mut battery = ec_service_lib::services::Battery::new();
+    let mut fw_mgmt = ec_service_lib::services::FwMgmt::new();
+    let mut notify = ec_service_lib::services::Notify::new();
+
+    let services = ec_service_lib::service_array![thermal, battery, fw_mgmt, notify];
+
     // Program VBAR_EL1 to our exception handlers
     // Call into the haf-ec-service sp_main
-    let service = haf_ec_service::HafEcService {
+    let service = ec_service_lib::HafEcService {
         rx_buffer_base: 0,
         tx_buffer_base: 0,
         rxtx_page_count: 0,
+        services: services.as_ref(),
     };
     service.sp_main();
 }


### PR DESCRIPTION
Refactor: Implement Service trait for modular message handling

This PR introduces a Service trait for HAF EC service components, which provides a cleaner, more maintainable architecture for message handling. Services implement standardized handlers for messages, rather than parse function IDs themselves. Platforms select the services they want to expose, rather than all of them being active (I imagine there will be some platforms that need other services but not others, custom services, etc). Platform vendors can implement custom services and pass them to the `HafEcService` ctor, using their own platform-specific UUIDs.

Key changes:

- Created a new Service trait with standard interface for all service implementations
- Moved service implementations to a dedicated services/ directory
- Implemented trait for Notify, FwMgmt, Battery, and Thermal services
- Refactored HafEcService to dispatch messages using service trait methods
- Added service_array! macro for easy service registration
- Updated platform code to use the new trait-based service system
- Renamed package from haf_ec_service to ec-service-lib for consistency