### PR TITLE
Use num_enum to do safe enum conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ name = "odp-ffa"
 version = "0.1.0"
 dependencies = [
  "log",
+ "num_enum",
  "rstest",
  "uuid",
 ]

--- a/odp-ffa/Cargo.toml
+++ b/odp-ffa/Cargo.toml
@@ -20,6 +20,7 @@ targets = ["aarch64-unknown-none", "aarch64-unknown-none-softfloat"]
 [dependencies]
 uuid = { workspace = true, default-features = false, features = ["v1"] }
 log.workspace = true
+num_enum.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true


### PR DESCRIPTION
Remove utility macro that was duplicated in the `num_enum` crate, which we already have listed as a dependency. 

Adds the `define_from_type` macro which is a small utility for defining `From` implementations in a concise way, in this case for converting from various error types into values of our odp-ffa specific Error enum.