### PR TITLE
Add hf_interrupt_reconfigure, hook before message is dispatched to handler

### DIFF
--- a/ec-service-lib/src/service.rs
+++ b/ec-service-lib/src/service.rs
@@ -27,8 +27,11 @@ pub struct ServiceNode<This: Service, Next: ServiceNodeHandler> {
 }
 
 impl<This: Service, Next: ServiceNodeHandler> ServiceNode<This, Next> {
-    pub async fn run_message_loop(&mut self) -> Result<()> {
-        async_msg_loop(async |msg| self.handle(msg).await).await
+    pub async fn run_message_loop(
+        &mut self,
+        before_handle_message: impl AsyncFnMut(&MsgSendDirectReq2) -> core::result::Result<(), odp_ffa::Error>,
+    ) -> Result<()> {
+        async_msg_loop(async |msg| self.handle(msg).await, before_handle_message).await
     }
 }
 

--- a/hafnium/src/lib.rs
+++ b/hafnium/src/lib.rs
@@ -25,6 +25,15 @@ pub enum InterruptType {
     Fiq = 1,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(unused)]
+#[repr(u64)]
+pub enum InterruptReconfigureCommand {
+    TargetPe = 0,
+    SecState = 1,
+    Enable = 2,
+}
+
 /// Makes a hypervisor call with the specified arguments.
 ///
 /// # Arguments
@@ -94,6 +103,19 @@ pub fn hf_interrupt_get() -> Option<InterruptId> {
 pub fn hf_interrupt_deactivate(intid: InterruptId) -> Result<(), i64> {
     let intid = intid.0 as u64;
     let result = hf_call(HfCall::InterruptDeactivate, intid, intid, 0);
+    match result {
+        0 => Ok(()),
+        _ => Err(result),
+    }
+}
+
+pub fn hf_interrupt_reconfigure(
+    intid: InterruptId,
+    command: InterruptReconfigureCommand,
+    value: u64,
+) -> Result<(), i64> {
+    let intid = intid.0 as u64;
+    let result = hf_call(HfCall::InterruptReconfigure, intid, command as u64, value);
     match result {
         0 => Ok(()),
         _ => Err(result),

--- a/odp-ffa/src/lib.rs
+++ b/odp-ffa/src/lib.rs
@@ -61,6 +61,7 @@ pub enum Error {
     UnexpectedFunctionId(FunctionId),
     InvalidErrorCode(i64),
     ErrorCode(ErrorCode),
+    HafniumError(i64),
     TooManySmcParams,
     Other(&'static str),
 }

--- a/platform/ihv1-sp/src/baremetal/mod.rs
+++ b/platform/ihv1-sp/src/baremetal/mod.rs
@@ -3,7 +3,7 @@ mod panic;
 mod services;
 
 use aarch64_rt::entry;
-use ec_service_lib::{service_list, sp_logger::SpLogger};
+use ec_service_lib::sp_logger::SpLogger;
 
 entry!(aarch64_rt_main);
 fn aarch64_rt_main(_arg0: u64, _arg1: u64, _arg2: u64, _arg3: u64) -> ! {

--- a/platform/ihv1-sp/src/main.rs
+++ b/platform/ihv1-sp/src/main.rs
@@ -21,7 +21,7 @@ async fn embassy_main(_spawner: embassy_executor::Spawner) {
 
     log::info!("IHV1 Secure Partition - build time: {}", env!("BUILD_TIME"));
     service_list![ec_service_lib::services::Thermal::new()]
-        .run_message_loop()
+        .run_message_loop(async |_| Ok(()))
         .await
         .expect("Error in run_message_loop");
 }

--- a/platform/qemu-sp/src/main.rs
+++ b/platform/qemu-sp/src/main.rs
@@ -25,7 +25,7 @@ async fn embassy_main(_spawner: embassy_executor::Spawner) {
         ec_service_lib::services::FwMgmt::new(),
         ec_service_lib::services::Notify::new()
     ]
-    .run_message_loop()
+    .run_message_loop(async |_| Ok(()))
     .await
     .expect("Error in run_message_loop");
 }


### PR DESCRIPTION
Add a hook to the async message loop to allow the user inspect the received FFA message and do something accordingly. Namely, we want to allow the platform to reconfigure interrupts for the correct PE.  

In that vein, adds `hf_interrupt_reconfigure` and supporting types.