### PR TITLE
Updating QEMU support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "hafnium",
  "log",
  "odp-ffa",
+ "uuid",
 ]
 
 [[package]]

--- a/ec-service-lib/src/services/fw_mgmt.rs
+++ b/ec-service-lib/src/services/fw_mgmt.rs
@@ -14,7 +14,6 @@ const EC_CAP_MAP_SHARE: u8 = 0x5;
 
 #[derive(Default)]
 struct FwStateRsp {
-    status: i64,
     fw_version: u16,
     secure_state: u8,
     boot_status: u8,
@@ -23,10 +22,9 @@ struct FwStateRsp {
 impl From<FwStateRsp> for RegisterPayload {
     fn from(rsp: FwStateRsp) -> Self {
         let iter = rsp
-            .status
+            .fw_version
             .to_le_bytes()
             .into_iter()
-            .chain(rsp.fw_version.to_le_bytes())
             .chain(rsp.secure_state.to_le_bytes())
             .chain(rsp.boot_status.to_le_bytes());
 
@@ -96,7 +94,6 @@ impl FwMgmt {
 
     fn get_fw_state(&self) -> FwStateRsp {
         FwStateRsp {
-            status: 0x0,
             fw_version: 0x0100,
             secure_state: 0x0,
             boot_status: 0x1,

--- a/platform/qemu-sp/Cargo.toml
+++ b/platform/qemu-sp/Cargo.toml
@@ -30,6 +30,7 @@ hafnium = { workspace = true, optional = true }
 log.workspace = true
 embassy-executor.workspace = true
 embassy-sync.workspace = true
+uuid.workspace = true
 
 
 [build-dependencies]

--- a/platform/qemu-sp/linker/qemu-ec-sp.dts
+++ b/platform/qemu-sp/linker/qemu-ec-sp.dts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020-21, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+#define MODE_SEL0	(0x1)
+#define MODE_SEL1	(0x2)
+
+#define SECURE_RO 0x1
+#define SECURE_RW 0x3
+#define SECURE_EXECUTE_RO 0x5
+#define SECURE_EXECUTE_RW 0x7
+#define NON_SECURE_RO 0x9
+#define NON_SECURE_RW 0xB
+#define NON_SECURE_EXECUTE_RO 0xD
+#define NONSECURE_EXECUTE_RW 0xF
+	/*
+	 * EC Service partition handles the following UUID'S
+	 * INTER-PARTITION      e474d87e-5731-4044-a727-cb3e8cf3c8df
+	 * EC_SVC_MANAGEMENT 	330c1273-fde5-4757-9819-5b6539037502
+	 * EC_SVC_POWER 		7157addf-2fbe-4c63-ae95-efac16e3b01c
+	 * EC_SVC_BATTERY 		25cb5207-ac36-427d-aaef-3aa78877d27e
+	 * EC_SVC_THERMAL		31f56da7-593c-4d72-a4b3-8fc7171ac073
+	 */
+
+	compatible = "arm,ffa-manifest-1.0";
+
+	description = "EC Services";
+	ffa-version = <0x00010002>; /* 31:16 - Major, 15:0 - Minor */
+	uuid = <0x7ed874e4 0x44403157 0x3ecb27a7 0xdfc8f38c>,
+		   <0x73120c33 0x5747e5fd 0x655b1998 0x02750339>,
+		   <0xdfad5771 0x634cbe2f 0xacef95ae 0x1cb0e316>,
+                   <0x0752cb25 0x7d4236ac 0xa73aefaa 0x7ed27788>,
+		   <0xa76df531 0x724d3c59 0xc78fb3a4 0x73c01a17>;
+	id = <0x8002>;
+	execution-ctx-count = <1>;
+	exception-level = <2>; /* SEL1*/
+	execution-state = <0>; /* AArch64*/
+	load-address = <0x0 0x20400000>;
+	entrypoint-offset = <0x10000>;
+	image-size = <0x0 0x50000>;
+	xlat-granule = <0>; /* 4KiB */
+	boot-order = <2>;
+	messaging-method = <0x603>; /* Direct request/response req2/rsp2 supported. */
+	ns-interrupts-action = <0>; /* Non-secure interrupt is signaled */
+	notification-support; /* Support receipt of notifications. */
+	gp-register-num = <0>;
+
+	boot-info {
+		compatible = "arm,ffa-manifest-boot-info";
+		ffa_manifest;
+	};
+
+	memory-regions {
+		compatible = "arm,ffa-manifest-memory-regions";
+
+		// Heap used by RUST code in SP
+		heap {
+			description = "heap";
+			base-address = <0x0 0x20500000>;
+			pages-count = <0x100>; /* 1MB of Heap space */
+			attributes = <0x3>;
+		};
+		
+		/*
+		 * Memory shared between Normal world and S-EL0.
+		 * Similar to ARM_SP_IMAGE_NS_BUF_MMAP.
+		 */
+		ns_comm_buffer {
+			description = "ns-comm";
+			base-address = <0x00000100 0x60000000>;
+			pages-count = <0x800>;
+			attributes = <0xB>;
+		};
+
+	};
+
+};

--- a/platform/qemu-sp/src/baremetal/battery.rs
+++ b/platform/qemu-sp/src/baremetal/battery.rs
@@ -1,0 +1,110 @@
+use ec_service_lib::{Result, Service};
+use log::{debug, error};
+use odp_ffa::{MsgSendDirectReq2, MsgSendDirectResp2, Payload, RegisterPayload};
+use uuid::{uuid, Uuid};
+
+// Protocol CMD definitions for Battery
+const EC_BAT_GET_BIX: u8 = 0x1;
+const EC_BAT_GET_BST: u8 = 0x2;
+const EC_BAT_GET_PSR: u8 = 0x3;
+const EC_BAT_GET_PIF: u8 = 0x4;
+const EC_BAT_GET_BPS: u8 = 0x5;
+const EC_BAT_GET_BTP: u8 = 0x6;
+const EC_BAT_GET_BPT: u8 = 0x7;
+const EC_BAT_GET_BPC: u8 = 0x8;
+const EC_BAT_GET_BMC: u8 = 0x9;
+const EC_BAT_GET_BMD: u8 = 0xa;
+const EC_BAT_GET_BCT: u8 = 0xb;
+const EC_BAT_GET_BTM: u8 = 0xc;
+const EC_BAT_GET_BMS: u8 = 0xd;
+const EC_BAT_GET_BMA: u8 = 0xe;
+const EC_BAT_GET_STA: u8 = 0xf;
+
+#[derive(Default)]
+struct GenericRsp {
+    status: i64,
+}
+
+impl From<GenericRsp> for RegisterPayload {
+    fn from(value: GenericRsp) -> Self {
+        RegisterPayload::from_iter(value.status.to_le_bytes())
+    }
+}
+
+#[derive(Default)]
+struct BstRsp {
+    state: u32,
+    present_rate: u32,
+    remaining_cap: u32,
+    present_volt: u32,
+}
+
+impl From<BstRsp> for RegisterPayload {
+    fn from(value: BstRsp) -> Self {
+        let payload_regs = [value.state, value.present_rate, value.remaining_cap, value.present_volt];
+        RegisterPayload::from_iter(payload_regs.iter().flat_map(|&reg| u32::to_le_bytes(reg).into_iter()))
+    }
+}
+
+#[derive(Default)]
+pub struct Battery {}
+
+impl Battery {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn get_bst(&self, _msg: &MsgSendDirectReq2) -> BstRsp {
+        BstRsp {
+            state: 0x1,          // Battery discharging
+            present_rate: 500,   // Power being supplied to battery
+            remaining_cap: 5000, // Remaining capacity of battery
+            present_volt: 12000, // 12V or 12000mV
+        }
+    }
+
+    fn generic_test(&self, _msg: &MsgSendDirectReq2) -> GenericRsp {
+        GenericRsp { status: 0x0 }
+    }
+}
+
+const UUID: Uuid = uuid!("25cb5207-ac36-427d-aaef-3aa78877d27e");
+
+impl Service for Battery {
+    fn service_name(&self) -> &'static str {
+        "Battery"
+    }
+
+    fn service_uuid(&self) -> Uuid {
+        UUID
+    }
+
+    async fn ffa_msg_send_direct_req2(&mut self, msg: MsgSendDirectReq2) -> Result<MsgSendDirectResp2> {
+        let cmd = msg.u8_at(0);
+        debug!("Received Battery command 0x{:x}", cmd);
+
+        let payload = match cmd {
+            EC_BAT_GET_BIX => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BST => RegisterPayload::from(self.get_bst(&msg)),
+            EC_BAT_GET_PSR => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_PIF => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BPS => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BTP => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BPT => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BPC => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BMC => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BMD => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BCT => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BTM => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BMS => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_BMA => RegisterPayload::from(self.generic_test(&msg)),
+            EC_BAT_GET_STA => RegisterPayload::from(self.generic_test(&msg)),
+            _ => {
+                error!("Unknown Battery Command: {}", cmd);
+                return Err(odp_ffa::Error::Other("Unknown Battery Command"));
+            }
+        };
+
+        Ok(MsgSendDirectResp2::from_req_with_payload(&msg, payload))
+    }
+}

--- a/platform/qemu-sp/src/baremetal/mod.rs
+++ b/platform/qemu-sp/src/baremetal/mod.rs
@@ -1,7 +1,9 @@
+mod battery;
 mod interrupt;
 mod panic;
 
 use aarch64_rt::entry;
+pub use battery::Battery;
 use ec_service_lib::sp_logger::SpLogger;
 
 entry!(aarch64_rt_main);

--- a/platform/qemu-sp/src/main.rs
+++ b/platform/qemu-sp/src/main.rs
@@ -20,10 +20,12 @@ async fn embassy_main(_spawner: embassy_executor::Spawner) {
     use ec_service_lib::service_list;
 
     log::info!("QEMU Secure Partition - build time: {}", env!("BUILD_TIME"));
+
     service_list![
         ec_service_lib::services::Thermal::new(),
         ec_service_lib::services::FwMgmt::new(),
-        ec_service_lib::services::Notify::new()
+        ec_service_lib::services::Notify::new(),
+        baremetal::Battery::new()
     ]
     .run_message_loop(async |_| Ok(()))
     .await


### PR DESCRIPTION
Added DTS file which contains memory layout.
Added battery support for QEMU to validate BST command.
Fw Management call no longer uses status register.