### PR TITLE
fix: harden pre-commit hook — strict clippy + portable cargo test

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -43,11 +43,17 @@ check_rustup_target "aarch64-unknown-none"
 set -x
 
 # cargo deny --log-level=warn check
-cargo clippy --target=aarch64-unknown-none -p ihv1-ec-sp -p qemu-ec-sp
-cargo clippy
+cargo clippy --target=aarch64-unknown-none -p ihv1-ec-sp -p qemu-ec-sp -- -D warnings
+cargo clippy -- -D warnings
 cargo fmt --check
 cargo hack check --feature-powerset --exclude=ihv1-ec-sp --exclude=qemu-ec-sp
 cargo hack check --feature-powerset --target=aarch64-unknown-none
-cargo test -q
+HOST_TARGET=$(rustc -vV | sed -n 's/host: //p')
+if [ -z "$HOST_TARGET" ]; then
+    echo "Failed to determine Rust host target from \`rustc -vV\` output."
+    echo "Please verify that \`rustc -vV\` prints a valid \`host:\` line."
+    exit 1
+fi
+cargo test --target "$HOST_TARGET" -q
 cd "$PROJECT_DIR/platform/qemu-sp" && cargo build --target=aarch64-unknown-none
 cd "$PROJECT_DIR/platform/ihv1-sp" && cargo build --target=aarch64-unknown-none


### PR DESCRIPTION
## Summary

Two fixes to `.husky/pre-commit`:

1. **`cargo clippy -- -D warnings`** — treats clippy warnings as errors so warnings don't silently accumulate
2. **Portable `cargo test` target** — detects the host target dynamically via `rustc -vV` instead of running bare `cargo test`, which fails locally when `rust-toolchain.toml` installs `aarch64-unknown-none-softfloat` (transitive deps `futures-timer`/`slab` can't compile for that target)

## Why

- Bare `cargo test` fails on any machine where the aarch64 target is installed via `rust-toolchain.toml`
- Clippy warnings were silently passing — e.g. dead_code warnings would not cause pre-commit to fail
- CI passes because `dtolnay/rust-toolchain@stable` doesn't install the cross-compilation target for the test job

## Testing

Verified the full pre-commit hook passes locally on the current `main` branch with these changes applied.