### PR TITLE
Update source/destination values of DIRECT_REQ2

### DIFF
--- a/odp-ffa/src/function/msg/direct_message.rs
+++ b/odp-ffa/src/function/msg/direct_message.rs
@@ -23,7 +23,7 @@ impl TryFrom<DirectMessage> for SmcParams {
         let (uuid_high, uuid_low) = msg.uuid.as_u64_pair();
         SmcParams::try_from_iter(
             [
-                combine_low_high_u16(msg.source_id, msg.destination_id),
+                combine_low_high_u16(msg.destination_id, msg.source_id),
                 uuid_high.to_be(),
                 uuid_low.to_be(),
             ]
@@ -37,8 +37,8 @@ impl TryFrom<SmcParams> for DirectMessage {
     type Error = Error;
 
     fn try_from(value: SmcParams) -> Result<Self, Self::Error> {
-        let source_id = (value.x1 & 0xFFFF) as u16;
-        let destination_id = (value.x1 >> 16) as u16;
+        let destination_id = (value.x1 & 0xFFFF) as u16;
+        let source_id = (value.x1 >> 16) as u16;
 
         let uuid_high = u64::from_be(value.x2);
         let uuid_low = u64::from_be(value.x3);


### PR DESCRIPTION
## Description

The source and destination IDs look to be backwards via the FF-A specification for FFA_MSG_SEND_DIRECT_REQ2. The source is the upper 16 bits while the destination is the lower 16 bits. Flipped them to the correct order.

See Section 15.4 of the FF-A spec:
https://developer.arm.com/documentation/den0077/o/?lang=en

<p align="center">
  <img width="633" height="257" alt="image" src="https://github.com/user-attachments/assets/dc24b0a1-6e9a-471f-b852-f92230fd3fd6" />
</p>

<br>

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A