### PR TITLE
TPM Service Updates

### DIFF
--- a/ec-service-lib/src/services/tpm.rs
+++ b/ec-service-lib/src/services/tpm.rs
@@ -581,9 +581,9 @@ impl<S: TpmSstOps> TpmService<S> {
     /// # Safety
     /// Function initializes the internal CRB at all localities by calling
     /// init_internal_crb. This sets all locality regions to known valid
-    /// values. The internal TPM CRB address must be a valid memory region
-    /// passed in by the caller.
-    pub unsafe fn init(&mut self, tpm_internal_crb_address: u64) {
+    /// values. The internal and external TPM CRB addresses must be valid
+    /// memory regions passed in by the caller.
+    pub unsafe fn init(&mut self, tpm_internal_crb_address: u64, tpm_external_crb_address: u64) {
         // Build the default interface ID.
         self.interface_id_default = PtpCrbInterfaceIdentifier::new();
         self.interface_id_default
@@ -601,7 +601,7 @@ impl<S: TpmSstOps> TpmService<S> {
         }
 
         // Initialize the TPM Service State Translation Library.
-        self.sst.init(0x60120000);
+        self.sst.init(tpm_external_crb_address);
 
         self.current_state = TpmState::Idle;
         self.active_locality = NO_ACTIVE_LOCALITY;
@@ -757,7 +757,7 @@ mod tests {
         fn is_idle_bypass_supported(&self) -> bool {
             false
         }
-        fn init(&mut self, _internal_tpm_address: u64) {
+        fn init(&mut self, _tpm_external_crb_address: u64) {
             // Do nothing
         }
     }
@@ -991,7 +991,8 @@ mod tests {
     fn test_start_locality_request() {
         let (buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
-        unsafe { service.init(addr) };
+        let tpm_external_crb_address: u64 = 0x60120000;
+        unsafe { service.init(addr, tpm_external_crb_address) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };
 
         let open_msg = direct_req2_msg(
@@ -1024,7 +1025,8 @@ mod tests {
     fn test_start_command() {
         let (buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
-        unsafe { service.init(addr) };
+        let tpm_external_crb_address: u64 = 0x60120000;
+        unsafe { service.init(addr, tpm_external_crb_address) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };
 
         let open_msg = direct_req2_msg(
@@ -1100,7 +1102,8 @@ mod tests {
     fn test_start_locality_relinquish() {
         let (buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
-        unsafe { service.init(addr) };
+        let tpm_external_crb_address: u64 = 0x60120000;
+        unsafe { service.init(addr, tpm_external_crb_address) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };
 
         let open_msg = direct_req2_msg(

--- a/ec-service-lib/src/services/tpm.rs
+++ b/ec-service-lib/src/services/tpm.rs
@@ -715,6 +715,7 @@ mod tests {
     use odp_ffa::DirectMessagePayload;
 
     const TPM_SERVICE_UUID: Uuid = uuid!("17b862a4-1806-4faf-86b3-089a58353861");
+    const EXTERNAL_TPM_CRB_ADDR: u64 = 0x60120000;
 
     // =======================================================================
     // Mock CrbRegion
@@ -991,8 +992,7 @@ mod tests {
     fn test_start_locality_request() {
         let (buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
-        let tpm_external_crb_address: u64 = 0x60120000;
-        unsafe { service.init(addr, tpm_external_crb_address) };
+        unsafe { service.init(addr, EXTERNAL_TPM_CRB_ADDR) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };
 
         let open_msg = direct_req2_msg(
@@ -1025,8 +1025,7 @@ mod tests {
     fn test_start_command() {
         let (buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
-        let tpm_external_crb_address: u64 = 0x60120000;
-        unsafe { service.init(addr, tpm_external_crb_address) };
+        unsafe { service.init(addr, EXTERNAL_TPM_CRB_ADDR) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };
 
         let open_msg = direct_req2_msg(
@@ -1102,8 +1101,7 @@ mod tests {
     fn test_start_locality_relinquish() {
         let (buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
-        let tpm_external_crb_address: u64 = 0x60120000;
-        unsafe { service.init(addr, tpm_external_crb_address) };
+        unsafe { service.init(addr, EXTERNAL_TPM_CRB_ADDR) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };
 
         let open_msg = direct_req2_msg(

--- a/ec-service-lib/src/services/tpm_sst.rs
+++ b/ec-service-lib/src/services/tpm_sst.rs
@@ -148,7 +148,7 @@ pub trait TpmSstOps {
     fn locality_request(&mut self, locality: u8) -> ErrorCode;
     fn locality_relinquish(&mut self, locality: u8) -> ErrorCode;
     fn is_idle_bypass_supported(&self) -> bool;
-    fn init(&mut self, internal_tpm_address: u64);
+    fn init(&mut self, tpm_crb_address: u64);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Update the TPM service to allow the external (secure) TPM CRB address to be passed in. Doing so allows more flexibility. Otherwise, for different platforms (SBSA/VIRT) the addresses are different and can not be hard coded into the service or SST without needing to manually update them.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Passed all UnitTests. Verified on our SBSA platform with our SP passing both of the addresses to the init function. Verified TPM functionality.

## Integration Instructions

N/A
