### PR TITLE
Pin bit-register to version 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "bit-register"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/odp-utilities#583015c08ad9855f310bdb25d5cf9abff77b5e08"
+source = "git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0#583015c08ad9855f310bdb25d5cf9abff77b5e08"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ aarch64-rt = { version = "0.2.2", default-features = false, features = [
     "exceptions",
 ] }
 aarch64-haf = { path = "aarch64-haf" }
-bit-register = { git = "https://github.com/OpenDevicePartnership/odp-utilities" }
+bit-register = { git = "https://github.com/OpenDevicePartnership/odp-utilities", tag = "v0.1.0" }
 critical-section = { version = "1.1.0", default-features = false }
 debug-non-default = { git = "https://github.com/OpenDevicePartnership/odp-utilities" }
 ec-service-lib = { path = "ec-service-lib" }


### PR DESCRIPTION
This pull request makes a small but important update to the `Cargo.toml` dependencies. The `bit-register` dependency now pins to a specific version tag for improved build stability.

* Dependency management:
  * [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L26-R26): Updated the `bit-register` dependency to use the `v0.1.0` tag from the remote repository, ensuring consistent builds.