### PR TITLE
feat: add Battery FFA service + MCTP-via-PL011 EC relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,18 +39,12 @@ checksum = "683c4295f0608c531130ed6daf301785844c1f71eb126eb56343838968e728c5"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -63,18 +57,45 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version 0.2.3",
+]
+
+[[package]]
+name = "battery-service-interface"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#65fd654178ca82a424bfb2ba05846fbc607b51e9"
+dependencies = [
+ "embedded-batteries-async",
+]
+
+[[package]]
+name = "battery-service-relay"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#65fd654178ca82a424bfb2ba05846fbc607b51e9"
+dependencies = [
+ "battery-service-interface",
+ "embedded-services",
+ "num_enum",
+]
 
 [[package]]
 name = "bit-register"
@@ -85,45 +106,82 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.9.4"
+name = "bit-register"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/odp-utilities#583015c08ad9855f310bdb25d5cf9abff77b5e08"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
+name = "bitfield"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f798d2d157e547aa99aab0967df39edd0b70307312b6f8bd2848e6abe40896e0"
+
+[[package]]
+name = "bitfield-struct"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -136,6 +194,33 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cortex-m"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
+dependencies = [
+ "bare-metal",
+ "bitfield 0.13.2",
+ "embedded-hal 0.2.7",
+ "volatile-register",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "critical-section"
@@ -155,10 +240,111 @@ name = "ec-service-lib"
 version = "0.1.0"
 dependencies = [
  "aarch64-cpu",
+ "battery-service-interface",
+ "battery-service-relay",
+ "embedded-services",
  "log",
+ "mctp-rs",
  "num_enum",
  "odp-ffa",
+ "qemu-sp-uart",
  "uuid",
+]
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
+
+[[package]]
+name = "embassy-sync"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "embedded-io-async",
+ "futures-core",
+ "futures-sink",
+ "heapless",
+]
+
+[[package]]
+name = "embedded-batteries"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f975432b4e146342a1589c563cffab6b7a692024cb511bf87b6bfe78c84125"
+dependencies = [
+ "bitfield-struct",
+ "bitflags",
+ "embedded-hal 1.0.0",
+ "zerocopy",
+]
+
+[[package]]
+name = "embedded-batteries-async"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3bf0e4be67770cfc31f1cea8b73baf98c0baf2c57d6bd8c3a4c315acb1d8bd4"
+dependencies = [
+ "bitfield-struct",
+ "embedded-batteries",
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-crc-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1c75747a43b086df1a87fb2a889590bc0725e0abf54bba6d0c4bf7bd9e762c"
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "embedded-io-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "embedded-services"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#65fd654178ca82a424bfb2ba05846fbc607b51e9"
+dependencies = [
+ "bitfield 0.17.0",
+ "cortex-m",
+ "critical-section",
+ "embassy-futures",
+ "embassy-sync",
+ "mctp-rs",
+ "paste",
+ "portable-atomic",
+ "serde",
 ]
 
 [[package]]
@@ -171,7 +357,20 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "espi-device"
 version = "0.1.0"
 dependencies = [
- "bit-register",
+ "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0)",
+ "bitflags",
+ "num-traits",
+ "num_enum",
+ "static_assertions",
+ "subenum",
+]
+
+[[package]]
+name = "espi-device"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#290aa80a4c281857f3bed94581200b330119286c"
+dependencies = [
+ "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0)",
  "bitflags",
  "num-traits",
  "num_enum",
@@ -183,58 +382,69 @@ dependencies = [
 name = "espi-device-stub"
 version = "0.1.0"
 dependencies = [
- "espi-device",
+ "espi-device 0.1.0",
  "log",
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
-name = "futures-task"
-version = "0.3.31"
+name = "futures-sink"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hafnium"
@@ -245,28 +455,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.3"
+name = "hash32"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "husky-rs"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b00c51c8ea1f7e8d93caaf071948f766eb331cd55cb9871096614c9291642e"
+checksum = "7efd8aa8491dc34722e4038a2fff2ce6cf1343976c81aa94bc1da5eeb6b7d2b2"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -296,7 +525,7 @@ dependencies = [
  "aarch64-rt",
  "chrono",
  "ec-service-lib",
- "espi-device",
+ "espi-device 0.1.0",
  "espi-device-stub",
  "hafnium",
  "log",
@@ -306,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -316,31 +545,61 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mctp-rs"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#65fd654178ca82a424bfb2ba05846fbc607b51e9"
+dependencies = [
+ "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities)",
+ "crc",
+ "espi-device 0.1.0 (git+https://github.com/OpenDevicePartnership/haf-ec-service)",
+ "num_enum",
+ "smbus-pec",
+ "thiserror",
+]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "num-traits"
@@ -353,22 +612,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -383,36 +643,42 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "portable-atomic"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -439,18 +705,18 @@ version = "0.1.0"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -460,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -471,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relative-path"
@@ -505,9 +771,18 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "rustc_version",
- "syn 2.0.100",
+ "rustc_version 0.4.1",
+ "syn",
  "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -516,20 +791,65 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "shlex"
@@ -539,12 +859,24 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smbus-pec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0763a680cd5d72b28f7bfc8a054c117d8841380a6ad4f72f05bd2a34217d3e"
 dependencies = [
- "autocfg",
+ "embedded-crc-macros",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -554,32 +886,21 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subenum"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5d5dfb8556dd04017db5e318bbeac8ab2b0c67b76bf197bfb79e9b29f18ecf"
+checksum = "5eee3fb942ed39f3971438fcc7e05e20717e599e14c5c7cb50edd0df2a44b274"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -588,22 +909,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -614,67 +935,88 @@ checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.100"
+name = "vcell"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
+dependencies = [
+ "vcell",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -682,31 +1024,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "wasm-bindgen-backend",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -717,55 +1059,75 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "qemu-sp-uart"
+version = "0.1.0"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,15 @@ espi-device = { path = "espi-device" }
 espi-device-stub = { path = "espi-device-stub" }
 odp-ffa = { path = "odp-ffa" }
 hafnium = { path = "hafnium" }
+qemu-sp-uart = { path = "qemu-sp-uart" }
+
+mctp-rs = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false, features = ["serial"] }
+embedded-services = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
+battery-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
+battery-service-interface = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
 log = { version = "0.4", default-features = false }
 mockall = "0.13.1"
-num_enum = { version = "0.7.3", default-features = false }
+num_enum = { version = "0.7.5", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 subenum = { version = "1.1.2", default-features = false }
 uuid = { version = "1.0", default-features = false, features = ["v1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "platform/ihv1-sp",
     "platform/qemu-sp",
     "aarch64-haf",
+    "qemu-sp-uart",
 ]
 
 [workspace.package]

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     #{ id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; transitive dep via embedded-services. No safe upgrade available, awaiting upstream migration to pastey." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/ec-service-lib/Cargo.toml
+++ b/ec-service-lib/Cargo.toml
@@ -17,9 +17,23 @@ uuid.workspace = true
 odp-ffa.workspace = true
 num_enum.workspace = true
 log.workspace = true
+qemu-sp-uart.workspace = true
+mctp-rs = { workspace = true, features = ["serial"] }
 
 [target.'cfg(target_os = "none")'.dependencies]
 aarch64-cpu.workspace = true
+
+# Host-test-only deps. embedded-services + battery-service-relay pull in
+# embassy-sync::ThreadModeRawMutex which is cortex_m-only — they fail to
+# compile for aarch64-unknown-none[-softfloat]. The wire-format
+# unit test runs on the host (where std is available, satisfying the cfg
+# gate) and round-trips bytes through the EC's OWN SerializableMessage
+# impl, so SP-side EcBattery code performs MANUAL serialization at runtime
+# (trivial: 1-byte GetBst request payload, 4×LE-u32 response payload).
+[dev-dependencies]
+embedded-services.workspace = true
+battery-service-relay.workspace = true
+battery-service-interface.workspace = true
 
 [features]
 default = []

--- a/ec-service-lib/src/services/battery.rs
+++ b/ec-service-lib/src/services/battery.rs
@@ -1,0 +1,268 @@
+//! `Battery` — FFA service that proxies Normal-World `GetBst` requests
+//! to the EC's `BatteryServiceRelayHandler` over MCTP.
+//!
+//! Transport-agnostic via the [`crate::services::ec_relay::Relay`] trait.
+//! [`Battery`] is generic over `R: Relay`; the concrete relay impl
+//! (e.g. `EcRelay<MctpSerialTransport<Pl011Uart>>` in production, or
+//! `EcRelay<LoopbackTransport>` in tests) is inferred at the wiring
+//! call site. Battery itself never names a transport type.
+//!
+//! # Wire format (must match the EC's `OdpRelayHandler` byte-for-byte)
+//!
+//! Battery service id = `0x08`; `BatteryCmd::GetBst` = 2.
+//!
+//! Request body (5 bytes, post the MCTP `MESSAGE_TYPE = 0x7D` byte):
+//! ```text
+//!     [0x02, 0x08, 0x00, 0x02, 0x00]
+//!      \________________/  ^
+//!       OdpHeader (BE u32)  battery_id = 0
+//!       (req=1, svc=0x08,
+//!        is_error=0, msg_id=2)
+//! ```
+//!
+//! Response body (20 bytes): 4-byte BE OdpHeader (req=0, svc=0x08, msg_id=2)
+//! followed by 16 bytes (4 LE u32 dwords: `battery_state.bits()`,
+//! `battery_present_rate`, `battery_remaining_capacity`,
+//! `battery_present_voltage`).
+//!
+//! # SP-side runtime serialization is manual
+//!
+//! `embedded_services::relay::SerializableMessage` does not compile for
+//! `aarch64-unknown-none-softfloat` (the SBSA SP target) because
+//! `embassy-sync::ThreadModeRawMutex` is `cortex_m`-gated. As a
+//! workaround, SP-side runtime serialization for `GetBst` is performed
+//! MANUALLY (1-byte request payload; 4 LE u32 dwords for the response
+//! body). The wire-format gate test in the `tests` module below
+//! round-trips bytes through the EC's OWN `SerializableMessage` impl
+//! (via `[dev-dependencies]`) so any drift fails the build.
+
+use core::cell::RefCell;
+
+use uuid::{uuid, Uuid};
+
+use crate::services::ec_relay::{self, EcRelayError, Relay};
+use crate::{Result, Service};
+use odp_ffa::{Error as FfaError, MsgSendDirectReq2, MsgSendDirectResp2};
+
+/// Battery service id in the EC's `OdpRelayHandler` instantiation
+/// (canonical value at
+/// `OpenDevicePartnership/odp-embedded-controller::platform/platform-common/src/lib.rs:9`).
+pub const BATTERY_SERVICE_ID: u8 = 0x08;
+
+/// `BatteryCmd::GetBst` discriminant from
+/// `embedded-services/battery-service-relay/src/serialization.rs`.
+pub const BATTERY_CMD_GET_BST: u16 = 2;
+
+/// Body of a `GetBst` response, post-OdpHeader. 16 bytes (4 LE u32 dwords).
+pub const GET_BST_RESPONSE_BODY_LEN: usize = 16;
+
+/// Parsed `GetBst` response (mirrors
+/// `battery_service_interface::BstReturn` field-for-field but stays
+/// dependency-free at runtime).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BstReturnRaw {
+    pub battery_state: u32,
+    pub battery_present_rate: u32,
+    pub battery_remaining_capacity: u32,
+    pub battery_present_voltage: u32,
+}
+
+/// Errors returned by [`Battery::get_bst`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatteryError {
+    /// Relay (MCTP + transport) failure — see [`EcRelayError`].
+    Relay(EcRelayError),
+    /// EC's response was not a Battery service response or not the
+    /// expected message id.
+    UnexpectedResponse,
+}
+
+impl From<EcRelayError> for BatteryError {
+    fn from(e: EcRelayError) -> Self {
+        BatteryError::Relay(e)
+    }
+}
+
+/// `Battery` holds a handle to a shared [`Relay`] — it owns no
+/// transport, no assembly buffer, no MCTP framing state. Construction
+/// takes only a borrow of the wiring-layer-owned `RefCell<R>`.
+///
+/// Battery is generic over `R: Relay` rather than over a transport
+/// type: it never names `OdpTransport`, `MctpSerialTransport`, or any
+/// UART type. The concrete `R = EcRelay<T>` is inferred at the wiring
+/// call site. This keeps transport-layer details out of the service
+/// layer's API.
+///
+/// Future EC-proxy services (`EcThermal`, `EcFwMgmt`, `EcTimeAlarm`)
+/// follow the same pattern: `Self::new(relay: &'r RefCell<R>)`. They
+/// all share the single physical EC channel by borrowing the same
+/// `RefCell`-wrapped relay.
+pub struct Battery<'r, R: Relay> {
+    relay: &'r RefCell<R>,
+}
+
+impl<'r, R: Relay> Battery<'r, R> {
+    pub fn new(relay: &'r RefCell<R>) -> Self {
+        Self { relay }
+    }
+
+    /// Drive a single GetBst request/response round-trip over the EC
+    /// MCTP relay. Returns the parsed BST body or a relay/wire-format
+    /// error.
+    pub fn get_bst(&self, battery_id: u8) -> core::result::Result<BstReturnRaw, BatteryError> {
+        let request_header = ec_relay::build_odp_header(true, BATTERY_SERVICE_ID, BATTERY_CMD_GET_BST);
+        let request_body = [battery_id];
+
+        self.relay
+            .borrow_mut()
+            .invoke(request_header, &request_body, |response| {
+                if response.service_id != BATTERY_SERVICE_ID || response.message_id != BATTERY_CMD_GET_BST {
+                    return Err(EcRelayError::UnexpectedMessageType);
+                }
+                if response.body.len() < GET_BST_RESPONSE_BODY_LEN {
+                    return Err(EcRelayError::BodyTooShort);
+                }
+                let payload = &response.body[..GET_BST_RESPONSE_BODY_LEN];
+                Ok(BstReturnRaw {
+                    battery_state: u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]),
+                    battery_present_rate: u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]),
+                    battery_remaining_capacity: u32::from_le_bytes([payload[8], payload[9], payload[10], payload[11]]),
+                    battery_present_voltage: u32::from_le_bytes([payload[12], payload[13], payload[14], payload[15]]),
+                })
+            })
+            .map_err(BatteryError::Relay)
+    }
+}
+
+impl<R: Relay> Service for Battery<'_, R> {
+    const UUID: Uuid = uuid!("25cb5207-ac36-427d-aaef-3aa78877d27e");
+    const NAME: &'static str = "Battery";
+
+    fn ffa_msg_send_direct_req2(&mut self, msg: MsgSendDirectReq2) -> Result<MsgSendDirectResp2> {
+        // The EFI test-app sends a single GetBst with battery_id = 0
+        // (UEFI parses no payload bytes for this round-trip). Future
+        // callers may extract `battery_id` from msg.payload().u8_at(0).
+        match self.get_bst(0) {
+            Ok(bst) => {
+                // Pack the 16 BST bytes as 4 LE u32 dwords across the
+                // direct-message register payload (mirrors notify.rs's
+                // `From<NfyGenericRsp>` pattern of placing scalar
+                // values at the start of the payload).
+                let payload = odp_ffa::DirectMessagePayload::from_iter(
+                    bst.battery_state
+                        .to_le_bytes()
+                        .into_iter()
+                        .chain(bst.battery_present_rate.to_le_bytes())
+                        .chain(bst.battery_remaining_capacity.to_le_bytes())
+                        .chain(bst.battery_present_voltage.to_le_bytes()),
+                );
+                Ok(MsgSendDirectResp2::from_req_with_payload(&msg, payload))
+            }
+            Err(_) => Err(FfaError::Other(
+                "Battery: GetBst round-trip failed (transport or wire decode)",
+            )),
+        }
+    }
+}
+
+// ===========================================================================
+// Wire-format compatibility gate
+//
+// Round-trips bytes through the EC's OWN `SerializableMessage::serialize` /
+// `deserialize` impls from `embedded-services/battery-service-relay`. Any
+// drift in field order, endianness, or discriminant numbering causes the
+// assertion to fail. Runs on host (std available) — no QEMU.
+// ===========================================================================
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::ec_relay::test_util::{frame_response_packets, LoopbackTransport};
+    use crate::services::ec_relay::EcRelay;
+    use battery_service_interface::{BatteryState, BstReturn};
+    use battery_service_relay::{AcpiBatteryRequest, AcpiBatteryResponse};
+    use embedded_services::relay::SerializableMessage;
+
+    fn canned_bst() -> BstReturn {
+        BstReturn {
+            battery_state: BatteryState::from_bits_truncate(0x0000_0001), // discharging
+            battery_present_rate: 0x1122_3344,
+            battery_remaining_capacity: 0x5566_7788,
+            battery_present_voltage: 0x99AA_BBCC,
+        }
+    }
+
+    #[test]
+    fn produces_canonical_get_bst_request_bytes() {
+        // -- Synthesize a response so Battery::get_bst doesn't block on transport read.
+        let bst = canned_bst();
+        let mut response_payload = [0u8; 16];
+        let n = AcpiBatteryResponse::GetBst { bst }
+            .serialize(&mut response_payload)
+            .expect("ec-side serialize");
+        assert_eq!(n, 16, "GetBst response body must be 16 bytes");
+
+        let response_header = ec_relay::build_odp_header(false, BATTERY_SERVICE_ID, BATTERY_CMD_GET_BST);
+        let framed_response = frame_response_packets(response_header, &response_payload);
+
+        // -- Construct the shared EcRelay (wrapping a loopback transport)
+        //    and hand a borrow to the Battery service.
+        let mut transport = LoopbackTransport::new();
+        transport.prime_rx(framed_response.iter().copied());
+        let relay = RefCell::new(EcRelay::new(transport));
+        let svc = Battery::new(&relay);
+
+        // -- Drive the round-trip.
+        let result = svc.get_bst(0).expect("get_bst should decode synthesized response");
+
+        // -- ASSERT 1 (request side, byte-level):
+        //    Battery's TX bytes (MCTP-framed) decode back to exactly:
+        //      OdpHeader [0x02, 0x08, 0x00, 0x02]  +  payload [0x00]
+        let tx_bytes = relay.borrow().transport().tx.clone();
+        let inner_tx = strip_mctp_framing(&tx_bytes);
+        assert_eq!(
+            inner_tx,
+            std::vec![0x02, 0x08, 0x00, 0x02, 0x00],
+            "Battery GetBst request wire bytes must match the EC's expected encoding exactly"
+        );
+
+        // -- ASSERT 2 (round-trip via the EC's OWN deserializer):
+        //    The bytes Battery produced parse back to GetBst { battery_id: 0 }
+        //    via `AcpiBatteryRequest::deserialize`.
+        let (is_req, svc_id, _is_err, msg_id) = ec_relay::parse_odp_header(&inner_tx[..4]).expect("parse header");
+        assert!(is_req, "must be a request");
+        assert_eq!(svc_id, BATTERY_SERVICE_ID);
+        assert_eq!(msg_id, BATTERY_CMD_GET_BST);
+        let decoded = AcpiBatteryRequest::deserialize(msg_id, &inner_tx[4..])
+            .expect("ec-side decoder must accept SP-produced bytes");
+        assert!(
+            matches!(decoded, AcpiBatteryRequest::GetBst { battery_id: 0 }),
+            "EC-side decoder must reconstruct the original request variant"
+        );
+
+        // -- ASSERT 3 (response side): Battery returned the BST values
+        //    synthesized at the top.
+        assert_eq!(result.battery_state, bst.battery_state.bits());
+        assert_eq!(result.battery_present_rate, bst.battery_present_rate);
+        assert_eq!(result.battery_remaining_capacity, bst.battery_remaining_capacity);
+        assert_eq!(result.battery_present_voltage, bst.battery_present_voltage);
+    }
+
+    /// Strip MCTP serial framing from the bytes Battery emitted on TX.
+    /// Returns the inner body (post the MCTP-message-type byte): 4 bytes
+    /// of OdpHeader + N bytes of serialized payload.
+    fn strip_mctp_framing(framed: &[u8]) -> std::vec::Vec<u8> {
+        use mctp_rs::{MctpPacketContext, MctpSerialMedium};
+        let mut buf = [0u8; 256];
+        let mut ctx = MctpPacketContext::<MctpSerialMedium>::new(MctpSerialMedium, &mut buf);
+        let message = ctx
+            .deserialize_packet(framed)
+            .expect("deserialize_packet ok")
+            .expect("complete message");
+        assert_eq!(message.message_buffer.message_type(), ec_relay::ODP_MESSAGE_TYPE);
+        message.message_buffer.body().to_vec()
+    }
+}

--- a/ec-service-lib/src/services/ec_relay.rs
+++ b/ec-service-lib/src/services/ec_relay.rs
@@ -1,0 +1,548 @@
+//! `ec_relay` — generic ODP-over-MCTP relay infrastructure for SP-side
+//! FFA services that proxy requests to the EC firmware.
+//!
+//! # Architecture
+//!
+//! The EC firmware exposes a set of services (Battery, Thermal, FwMgmt,
+//! TimeAlarm) behind a single [`uart_service::Service`] that wraps an
+//! [`mctp_rs::MctpMedium`] over a UART. SP-side FFA services that proxy
+//! to the EC all need the same three-step dance:
+//!
+//! 1. Build a 4-byte [`OdpHeader`]-style bitfield identifying the target
+//!    service + message id.
+//! 2. MCTP-frame the header + body into a wire-ready packet and write
+//!    it to a transport.
+//! 3. Read a framed response packet back from the transport, MCTP-strip
+//!    it, return the response header + body to the caller.
+//!
+//! This module owns steps 1–3. Per-service SP-side code (e.g.
+//! [`crate::services::battery::Battery`]) defines only the
+//! service-specific bits: service id, message id discriminants,
+//! request/response struct shapes, and `From<&[u8]>` / `Into<Vec<u8>>`
+//! conversions.
+//!
+//! # Transport abstraction
+//!
+//! [`OdpTransport`] decouples the relay framing from the physical wire.
+//! [`MctpSerialTransport`] is the concrete impl for MCTP-via-PL011-UART
+//! used by `qemu-ec-sp`; a hypothetical SmbusEspi transport would
+//! implement the trait identically. Per-service code (`Battery`,
+//! future `Thermal`, etc.) is generic over `T: OdpTransport` and never
+//! sees UART types.
+//!
+//! # Wire-format compatibility
+//!
+//! Bytes produced by [`build_request_header`] + caller-supplied body
+//! are byte-for-byte identical to what
+//! `embedded-services::relay::SerializableMessage::serialize` emits on
+//! the EC side. Drift is caught by the wire-format gate test in
+//! `services::battery::tests` (which round-trips bytes through the EC's
+//! OWN `SerializableMessage` impl).
+
+use mctp_rs::{
+    EndpointId, MctpMedium, MctpMessageHeaderTrait, MctpMessageTag, MctpMessageTrait, MctpPacketContext,
+    MctpPacketError, MctpPacketResult, MctpReplyContext, MctpSequenceNumber, MctpSerialMedium, EC_EID, SP_EID,
+};
+
+// ===========================================================================
+// ODP wire-format constants + bitfield helpers
+// ===========================================================================
+
+/// MCTP message-type byte for ODP relay traffic. Matches the EC's
+/// `impl_odp_mctp_relay_handler!` `HostRequest::MESSAGE_TYPE` constant in
+/// `embedded-services::relay::mctp`.
+pub const ODP_MESSAGE_TYPE: u8 = 0x7D;
+
+/// Build a 4-byte big-endian OdpHeader from its bitfield components.
+///
+/// Bitfield layout (matches `OdpHeaderWireFormat` in
+/// `embedded-services/embedded-service/src/relay/mod.rs:285-303`):
+///
+/// | bit 25 | bits 23..16 | bit 15   | bits 14..0  |
+/// |--------|-------------|----------|-------------|
+/// | is_req | service_id  | is_error | message_id  |
+///
+/// `is_error` is always 0 (only success responses are produced
+/// by the EC mock services we proxy to).
+pub fn build_odp_header(is_request: bool, service_id: u8, message_id: u16) -> [u8; 4] {
+    let mut raw: u32 = 0;
+    if is_request {
+        raw |= 1 << 25;
+    }
+    raw |= (service_id as u32) << 16;
+    raw |= (message_id as u32) & 0x7FFF;
+    raw.to_be_bytes()
+}
+
+/// Parse a 4-byte BE OdpHeader; returns `(is_request, service_id, is_error, message_id)`.
+pub fn parse_odp_header(bytes: &[u8]) -> Result<(bool, u8, bool, u16), &'static str> {
+    if bytes.len() < 4 {
+        return Err("OdpHeader buffer < 4 bytes");
+    }
+    let raw = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let is_request = (raw & (1 << 25)) != 0;
+    let service_id = ((raw >> 16) & 0xFF) as u8;
+    let is_error = (raw & (1 << 15)) != 0;
+    let message_id = (raw & 0x7FFF) as u16;
+    Ok((is_request, service_id, is_error, message_id))
+}
+
+// ===========================================================================
+// MctpMessageTrait shims so `MctpPacketContext::serialize_packet` accepts
+// our raw header + body bytes (no full SerializableMessage impl needed).
+// ===========================================================================
+
+/// Wraps the 4 BE bytes of an OdpHeader for use with
+/// [`MctpPacketContext::serialize_packet`].
+pub struct OdpRawHeader(pub [u8; 4]);
+
+impl MctpMessageHeaderTrait for OdpRawHeader {
+    fn serialize<M: MctpMedium>(self, buffer: &mut [u8]) -> MctpPacketResult<usize, M> {
+        if buffer.len() < 4 {
+            return Err(MctpPacketError::SerializeError("buffer too small for odp raw header"));
+        }
+        buffer[..4].copy_from_slice(&self.0);
+        Ok(4)
+    }
+
+    fn deserialize<M: MctpMedium>(buffer: &[u8]) -> MctpPacketResult<(Self, &[u8]), M> {
+        if buffer.len() < 4 {
+            return Err(MctpPacketError::HeaderParseError("buffer too small for odp raw header"));
+        }
+        let mut h = [0u8; 4];
+        h.copy_from_slice(&buffer[..4]);
+        Ok((OdpRawHeader(h), &buffer[4..]))
+    }
+}
+
+/// Wraps the body bytes (post-OdpHeader) of an ODP relay message — i.e.
+/// the `SerializableMessage::serialize` output for a specific
+/// request/response variant. SP-side this is constructed manually by
+/// per-service callers; the wire bytes match the EC's decoder by
+/// construction (verified per-service in its `tests` module).
+pub struct OdpRawMessage<'b>(pub &'b [u8]);
+
+impl<'buf> MctpMessageTrait<'buf> for OdpRawMessage<'buf> {
+    type Header = OdpRawHeader;
+    const MESSAGE_TYPE: u8 = ODP_MESSAGE_TYPE;
+
+    fn serialize<M: MctpMedium>(self, buffer: &mut [u8]) -> MctpPacketResult<usize, M> {
+        let n = self.0.len();
+        if buffer.len() < n {
+            return Err(MctpPacketError::SerializeError("buffer too small for odp raw body"));
+        }
+        buffer[..n].copy_from_slice(self.0);
+        Ok(n)
+    }
+
+    fn deserialize<M: MctpMedium>(_h: &OdpRawHeader, buffer: &'buf [u8]) -> MctpPacketResult<Self, M> {
+        Ok(OdpRawMessage(buffer))
+    }
+}
+
+// ===========================================================================
+// Transport abstraction
+// ===========================================================================
+
+/// Errors returned by the relay invocation path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EcRelayError {
+    /// Transport-layer write failure (UART TX, SMBUS NACK, etc.).
+    TransportWrite,
+    /// Transport-layer read failure (UART RX timeout, etc.).
+    TransportRead,
+    /// `MctpPacketContext::serialize_packet` failed.
+    MctpSerialize(&'static str),
+    /// Bytes received from transport could not be parsed as a complete
+    /// MCTP packet (e.g., framing mismatch, body too long for the
+    /// assembly buffer).
+    MctpDecode(&'static str),
+    /// `MctpPacketContext::deserialize_packet` returned `None` (partial
+    /// packet — the transport delivered an incomplete frame).
+    MctpRecvIncomplete,
+    /// Response packet's MCTP message-type byte was not [`ODP_MESSAGE_TYPE`].
+    UnexpectedMessageType,
+    /// Response packet's OdpHeader could not be parsed.
+    OdpHeaderParse(&'static str),
+    /// Response body was shorter than the per-service expected length.
+    BodyTooShort,
+}
+
+/// Transport-agnostic packet I/O. An [`OdpTransport`] knows how to:
+/// - write a wire-ready, already-MCTP-framed packet to its wire, and
+/// - read one back, returning the framed packet bytes verbatim for the
+///   relay to MCTP-strip.
+///
+/// Implementations decide their own framing-aware read strategy (e.g.,
+/// "read until [`MctpSerialMedium`] sentinel 0x7E"). The trait deliberately
+/// does NOT couple to a specific medium — a hypothetical
+/// `MctpSmbusEspiTransport` would use length-prefix framing and implement
+/// the same trait.
+pub trait OdpTransport {
+    fn send_packet(&mut self, packet: &[u8]) -> Result<(), EcRelayError>;
+
+    /// Read one complete framed packet into `buf`; return the number of
+    /// bytes consumed. Implementation chooses framing strategy based on
+    /// its medium.
+    fn recv_framed_packet(&mut self, buf: &mut [u8]) -> Result<usize, EcRelayError>;
+}
+
+/// MCTP-via-PL011-UART transport. Reads byte-at-a-time until the DSP0253
+/// 0x7E END flag appears, framing-aware-by-construction. Wraps any
+/// `UartIo`-implementing UART driver.
+pub struct MctpSerialTransport<U: UartIo> {
+    uart: U,
+}
+
+impl<U: UartIo> MctpSerialTransport<U> {
+    pub fn new(uart: U) -> Self {
+        Self { uart }
+    }
+}
+
+/// MCTP serial framing END flag (DSP0253 0x7E). Re-exported from the
+/// transport's framing for documentation only — callers don't need it.
+const SERIAL_END_FLAG: u8 = 0x7E;
+
+impl<U: UartIo> OdpTransport for MctpSerialTransport<U> {
+    fn send_packet(&mut self, packet: &[u8]) -> Result<(), EcRelayError> {
+        self.uart.write_bytes(packet).map_err(|_| EcRelayError::TransportWrite)
+    }
+
+    fn recv_framed_packet(&mut self, buf: &mut [u8]) -> Result<usize, EcRelayError> {
+        // Read byte-at-a-time until the DSP0253 END flag (0x7E) appears
+        // at the end of the framed packet.
+        let mut filled = 0usize;
+        loop {
+            if filled >= buf.len() {
+                return Err(EcRelayError::MctpRecvIncomplete);
+            }
+            let b = self
+                .uart
+                .read_byte_blocking()
+                .map_err(|_| EcRelayError::TransportRead)?;
+            buf[filled] = b;
+            filled += 1;
+            if b == SERIAL_END_FLAG {
+                return Ok(filled);
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// UART abstraction (consumed by MctpSerialTransport only)
+// ===========================================================================
+
+/// Minimal UART surface [`MctpSerialTransport`] needs. Implemented for
+/// `qemu_sp_uart::Pl011Uart<M>` for any `Mmio` backend; in tests, a
+/// Vec-backed mock substitutes.
+pub trait UartIo {
+    fn write_bytes(&mut self, bytes: &[u8]) -> core::result::Result<(), ()>;
+    fn read_byte_blocking(&mut self) -> core::result::Result<u8, ()>;
+}
+
+impl<M: qemu_sp_uart::Mmio> UartIo for qemu_sp_uart::Pl011Uart<M> {
+    fn write_bytes(&mut self, bytes: &[u8]) -> core::result::Result<(), ()> {
+        qemu_sp_uart::Pl011Uart::write_bytes(self, bytes).map_err(|_| ())
+    }
+    fn read_byte_blocking(&mut self) -> core::result::Result<u8, ()> {
+        qemu_sp_uart::Pl011Uart::read_byte_blocking(self).map_err(|_| ())
+    }
+}
+
+// ===========================================================================
+// Round-trip invocation: the generic operation per-service callers use.
+// ===========================================================================
+
+/// Decoded ODP response: header fields + body slice.
+///
+/// Body lifetime is bounded by the closure call in [`invoke`]. Parse
+/// inside the closure; only owned values can escape.
+#[allow(dead_code)] // is_request + is_error are exposed for future callers
+pub struct OdpResponse<'b> {
+    pub is_request: bool,
+    pub service_id: u8,
+    pub is_error: bool,
+    pub message_id: u16,
+    pub body: &'b [u8],
+}
+
+/// Service-layer view of "the channel to the EC". Decouples per-service
+/// code (`Battery`, future `EcThermal`, etc.) from transport-layer
+/// concerns: service code declares its dependency as `R: Relay` and
+/// never sees `OdpTransport`, UART types, or MCTP framing.
+///
+/// The shipped concrete impl is [`EcRelay<T>`] (an [`OdpTransport`]
+/// wrapping a UART). Alternative impls — diagnostic recorders,
+/// loopback mocks lighter than `EcRelay<LoopbackTransport>`, multiplex
+/// routers — can be added without touching service code.
+///
+/// # Object safety
+///
+/// `invoke` is generic over `R` (the closure return type) and `F` (the
+/// closure type), which makes this trait NOT object-safe. Use it as a
+/// bound (`R: Relay`) rather than a trait object (`dyn Relay`). The
+/// generic-method shape is necessary to support the borrow-bounded
+/// `&[u8]` response slice without forcing every caller to copy bytes
+/// out into an owned type.
+pub trait Relay {
+    fn invoke<R, F>(
+        &mut self,
+        request_header: [u8; 4],
+        request_body: &[u8],
+        parse_response: F,
+    ) -> Result<R, EcRelayError>
+    where
+        F: FnOnce(OdpResponse<'_>) -> Result<R, EcRelayError>;
+}
+
+/// Owning relay handle to the EC firmware over an `OdpTransport`. Owns
+/// the transport and the MCTP packet-assembly buffer. SP-side FFA
+/// services that proxy to the EC (`Battery`, future `EcThermal`, etc.)
+/// hold a borrow of a shared `RefCell<EcRelay<T>>`; they call
+/// `relay.borrow_mut().invoke(...)` per request and never touch the
+/// transport or buffer directly.
+///
+/// # Why this is a struct rather than free functions
+///
+/// The transport is a single physical resource (one PL011 UART). It
+/// must be owned by exactly one place. Service code shouldn't own it
+/// (multiple services can't co-own a UART, and "transport-aware
+/// service" is a layer violation). The wiring layer (`main.rs`) owns
+/// the `RefCell<EcRelay<T>>`; services borrow handles via the [`Relay`]
+/// trait.
+///
+/// # Single-threaded SP runtime
+///
+/// `RefCell` interior mutability is the right tool here: the SP runtime
+/// is single-threaded synchronous, so `borrow_mut` failures only happen
+/// on programming errors (nested calls into the same service while
+/// holding the relay). The runtime overhead is a single integer
+/// increment per call.
+pub struct EcRelay<T: OdpTransport> {
+    transport: T,
+    assembly_buf: [u8; 128],
+}
+
+impl<T: OdpTransport> EcRelay<T> {
+    pub fn new(transport: T) -> Self {
+        Self {
+            transport,
+            assembly_buf: [0u8; 128],
+        }
+    }
+
+    /// Test-only accessor for inspecting transport state (e.g. what bytes
+    /// the relay sent). Not part of the production API.
+    #[cfg(test)]
+    pub(crate) fn transport(&self) -> &T {
+        &self.transport
+    }
+}
+
+impl<T: OdpTransport> Relay for EcRelay<T> {
+    /// Perform one ODP request/response round-trip and parse the
+    /// response inside a caller-supplied closure.
+    ///
+    /// - Serializes `(request_header, request_body)` as an MCTP packet
+    ///   to the transport.
+    /// - Reads one framed packet back from the transport.
+    /// - MCTP-strips it; parses the OdpHeader; invokes `parse_response`
+    ///   with the resulting [`OdpResponse`] (whose `body` slice borrows
+    ///   from the relay's internal assembly buffer).
+    /// - Returns whatever owned value `parse_response` produced.
+    ///
+    /// The closure pattern is required because `MctpPacketContext` owns
+    /// the assembly buffer and the body slice it produces cannot
+    /// outlive the `MctpPacketContext`. Parsing inside the closure
+    /// guarantees only owned types escape.
+    fn invoke<R, F>(
+        &mut self,
+        request_header: [u8; 4],
+        request_body: &[u8],
+        parse_response: F,
+    ) -> Result<R, EcRelayError>
+    where
+        F: FnOnce(OdpResponse<'_>) -> Result<R, EcRelayError>,
+    {
+        // ----- 1. Serialize the request into a fresh MctpPacketContext
+        //          and push each emitted packet out the transport. Use
+        //          a dedicated TX buffer so assembly_buf is free for
+        //          the response.
+        {
+            let mut tx_buf = [0u8; 128];
+            let mut tx_ctx = MctpPacketContext::<MctpSerialMedium>::new(MctpSerialMedium, &mut tx_buf);
+            let reply_ctx = serial_reply_context(SP_EID, EC_EID);
+            let mut state = tx_ctx
+                .serialize_packet(reply_ctx, (OdpRawHeader(request_header), OdpRawMessage(request_body)))
+                .map_err(|e| EcRelayError::MctpSerialize(mctp_error_str(e)))?;
+            while let Some(pkt) = state.next() {
+                let pkt = pkt.map_err(|e| EcRelayError::MctpSerialize(mctp_error_str(e)))?;
+                self.transport.send_packet(pkt)?;
+            }
+        }
+
+        // ----- 2. Read one framed packet back into a small RX buffer.
+        let mut rx_packet = [0u8; 64];
+        let rx_len = self.transport.recv_framed_packet(&mut rx_packet)?;
+
+        // ----- 3. MCTP-strip via a fresh PacketContext borrowing
+        //          assembly_buf. The body slice we hand to
+        //          `parse_response` borrows from `rx_ctx`'s internal
+        //          buffer — it does NOT outlive this method. Callers
+        //          must extract owned values from the closure.
+        let mut rx_ctx = MctpPacketContext::<MctpSerialMedium>::new(MctpSerialMedium, &mut self.assembly_buf);
+        let message = rx_ctx
+            .deserialize_packet(&rx_packet[..rx_len])
+            .map_err(|e| EcRelayError::MctpDecode(mctp_error_str(e)))?
+            .ok_or(EcRelayError::MctpRecvIncomplete)?;
+
+        if message.message_buffer.message_type() != ODP_MESSAGE_TYPE {
+            return Err(EcRelayError::UnexpectedMessageType);
+        }
+
+        let body = message.message_buffer.body();
+        if body.len() < 4 {
+            return Err(EcRelayError::BodyTooShort);
+        }
+        let (is_request, service_id, is_error, message_id) =
+            parse_odp_header(body).map_err(EcRelayError::OdpHeaderParse)?;
+
+        parse_response(OdpResponse {
+            is_request,
+            service_id,
+            is_error,
+            message_id,
+            body: &body[4..],
+        })
+    }
+}
+
+/// Construct an `MctpReplyContext` for `MctpSerialMedium` traffic from
+/// `src` to `dst`. `MctpSerialMedium` has no per-medium addressing, so
+/// `medium_context = ()`.
+fn serial_reply_context(src: EndpointId, dst: EndpointId) -> MctpReplyContext<MctpSerialMedium> {
+    MctpReplyContext {
+        source_endpoint_id: src,
+        destination_endpoint_id: dst,
+        packet_sequence_number: MctpSequenceNumber::new(0),
+        message_tag: MctpMessageTag::try_from(0).expect("tag 0 always valid"),
+        medium_context: (),
+    }
+}
+
+fn mctp_error_str<M: MctpMedium>(e: MctpPacketError<M>) -> &'static str {
+    match e {
+        MctpPacketError::HeaderParseError(s) => s,
+        MctpPacketError::SerializeError(s) => s,
+        MctpPacketError::CommandParseError(s) => s,
+        MctpPacketError::MediumError(_) => "medium error",
+        MctpPacketError::ProtocolError(_) => "protocol error",
+        MctpPacketError::UnsupportedMessageType(_) => "unsupported message type",
+    }
+}
+
+// ===========================================================================
+// Loopback transport for unit tests (host-side only).
+// ===========================================================================
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+pub(crate) mod test_util {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::vec::Vec;
+
+    /// Test-only `OdpTransport` impl: records what was sent and serves
+    /// pre-loaded bytes on recv. Used by per-service test modules.
+    pub struct LoopbackTransport {
+        pub tx: Vec<u8>,
+        pub rx: VecDeque<u8>,
+    }
+
+    impl LoopbackTransport {
+        pub fn new() -> Self {
+            Self {
+                tx: Vec::new(),
+                rx: VecDeque::new(),
+            }
+        }
+
+        pub fn prime_rx<I: IntoIterator<Item = u8>>(&mut self, bytes: I) {
+            self.rx.extend(bytes);
+        }
+    }
+
+    impl OdpTransport for LoopbackTransport {
+        fn send_packet(&mut self, packet: &[u8]) -> Result<(), EcRelayError> {
+            self.tx.extend_from_slice(packet);
+            Ok(())
+        }
+
+        fn recv_framed_packet(&mut self, buf: &mut [u8]) -> Result<usize, EcRelayError> {
+            // Mirror MctpSerialTransport's framing: read until 0x7E.
+            let mut filled = 0usize;
+            loop {
+                if filled >= buf.len() {
+                    return Err(EcRelayError::MctpRecvIncomplete);
+                }
+                let b = self.rx.pop_front().ok_or(EcRelayError::TransportRead)?;
+                buf[filled] = b;
+                filled += 1;
+                if b == SERIAL_END_FLAG {
+                    return Ok(filled);
+                }
+            }
+        }
+    }
+
+    /// Helper used by per-service tests: synthesize a framed response
+    /// packet from `(response_header, response_body)` by running the
+    /// EC-side framing path (TX from EC_EID to SP_EID).
+    pub fn frame_response_packets(header: [u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut buf = [0u8; 256];
+        let mut ctx = MctpPacketContext::<MctpSerialMedium>::new(MctpSerialMedium, &mut buf);
+        let reply_ctx = serial_reply_context(EC_EID, SP_EID);
+        let mut wire: Vec<u8> = Vec::new();
+        let mut state = ctx
+            .serialize_packet(reply_ctx, (OdpRawHeader(header), OdpRawMessage(payload)))
+            .expect("serialize_packet ok");
+        while let Some(packet_result) = state.next() {
+            wire.extend_from_slice(packet_result.expect("packet ok"));
+        }
+        wire
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn odp_header_round_trip() {
+        let bytes = build_odp_header(true, 0x08, 2);
+        assert_eq!(bytes, [0x02, 0x08, 0x00, 0x02]);
+        let (is_req, svc, is_err, msg_id) = parse_odp_header(&bytes).unwrap();
+        assert!(is_req);
+        assert_eq!(svc, 0x08);
+        assert!(!is_err);
+        assert_eq!(msg_id, 2);
+    }
+
+    #[test]
+    fn odp_header_response_round_trip() {
+        let bytes = build_odp_header(false, 0x08, 2);
+        assert_eq!(bytes, [0x00, 0x08, 0x00, 0x02]);
+        let (is_req, _, is_err, _) = parse_odp_header(&bytes).unwrap();
+        assert!(!is_req);
+        assert!(!is_err);
+    }
+
+    #[test]
+    fn parse_odp_header_rejects_short_buffer() {
+        assert!(parse_odp_header(&[0x02, 0x08, 0x00]).is_err());
+    }
+}

--- a/ec-service-lib/src/services/mod.rs
+++ b/ec-service-lib/src/services/mod.rs
@@ -1,3 +1,5 @@
+mod battery;
+mod ec_relay;
 mod fw_mgmt;
 mod notify;
 mod thermal;
@@ -5,6 +7,8 @@ mod tpm;
 mod tpm_sst;
 mod tpm_stub;
 
+pub use battery::Battery;
+pub use ec_relay::{EcRelay, MctpSerialTransport, OdpTransport, Relay};
 pub use fw_mgmt::FwMgmt;
 pub use notify::Notify;
 pub use thermal::Thermal;

--- a/qemu-sp-uart/Cargo.toml
+++ b/qemu-sp-uart/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "qemu-sp-uart"
+description = "Minimal blocking PL011 MMIO driver for the QEMU SBSA secure partition"
+categories = ["embedded", "no-std", "no-std::no-alloc"]
+keywords = ["embedded", "no-std", "pl011", "uart", "qemu"]
+version.workspace = true
+edition.workspace = true
+license = "MIT"
+repository = "https://github.com/OpenDevicePartnership/odp-secure-services"
+
+[package.metadata.docs.rs]
+targets = ["aarch64-unknown-none", "aarch64-unknown-none-softfloat"]
+
+[dependencies]
+# Intentionally empty: this crate uses only `core` (no external deps; no allocator).
+
+[lints]
+workspace = true

--- a/qemu-sp-uart/README.md
+++ b/qemu-sp-uart/README.md
@@ -1,0 +1,39 @@
+# qemu-sp-uart
+
+Minimal blocking PL011 MMIO driver for the QEMU SBSA secure-partition's
+`ec_uart` device-region. `#![no_std]`, no allocator, no async — only
+`core` is used.
+
+## Public API
+
+- `Pl011Uart::new(base: u64) -> Self` (`unsafe`) — production constructor over
+  `RawMmio`; `base` is the SP-mapped device-region address.
+- `Pl011Uart::from_mmio(mmio: M) -> Self` — generic constructor for unit tests
+  (substitute a mock `Mmio` backend).
+- `Pl011Uart::write_bytes(&mut self, &[u8]) -> Result<(), Error>` — blocking
+  write; polls `UARTFR.TXFF` per byte.
+- `Pl011Uart::read_byte_blocking(&mut self) -> Result<u8, Error>` — busy-spin
+  forever until `UARTFR.RXFE` clears.
+- `Pl011Uart::read_byte_with_iteration_cap(&mut self, cap: u32)` — same loop
+  bounded by `cap` iterations; returns `Err(Error::Timeout)` if exhausted.
+
+## Base address
+
+Constructor-parameter-driven. The SP DTS declares `ec_uart` at `0x60030000`
+(`mod/secure-services/platform/linker/qemu-ec-sp.dts` line 106-108). The
+platform binary wires `Pl011Uart::new(0x60030000)` from `qemu-ec-sp::main`.
+The literal does NOT appear in this crate.
+
+## Targets
+
+Builds for both:
+
+- `aarch64-unknown-none-softfloat` (workspace default per `rust-toolchain.toml`)
+- `aarch64-unknown-none` (canonical embedded triple)
+
+## Safety
+
+`RawMmio::new(base)` is `unsafe`: caller must have mapped at least `0x40`
+bytes of device memory (R/W) at `base`, matching the SP manifest
+device-region attributes. The driver does NOT touch `UARTCR` / `UARTLCR_H`
+— TF-A and QEMU init are assumed.

--- a/qemu-sp-uart/src/lib.rs
+++ b/qemu-sp-uart/src/lib.rs
@@ -1,0 +1,271 @@
+#![no_std]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+
+//! Minimal blocking PL011 MMIO driver for the QEMU SBSA secure partition.
+//!
+//! Polled TX (blocks while `UARTFR.TXFF` is set) and polled RX (busy-wait,
+//! unbounded, via [`Pl011Uart::read_byte_blocking`]). MMIO is fronted by
+//! the [`Mmio`] trait so the bit-twiddling is host-testable with a mock
+//! backend.
+//!
+//! # Base address contract
+//!
+//! [`Pl011Uart::new`] takes the MMIO `base` as a constructor parameter; the
+//! literal device address (`0x60030000` for the SP-side `ec_uart` per
+//! `qemu-ec-sp.dts`) is NOT hard-coded inside this crate. The platform
+//! binary wires `Pl011Uart::new(0x60030000)` from `qemu-ec-sp::main`.
+//!
+//! # Safety contract
+//!
+//! [`RawMmio::new`] is `unsafe`: caller must have mapped the PL011 device
+//! region of at least `0x40` bytes at the supplied `base`, matching the SP
+//! manifest device-region attributes (R/W, device memory). The driver does
+//! NOT touch `UARTCR` / `UARTLCR_H` — TF-A and QEMU init are assumed.
+
+/// Minimal MMIO abstraction. Real hardware uses [`RawMmio`] with
+/// `core::ptr::{read,write}_volatile`; host tests substitute a mock backend.
+/// Offsets are byte offsets from the device base.
+pub trait Mmio {
+    /// Read a `u32` at byte offset `off` from the base.
+    ///
+    /// # Safety
+    /// Caller guarantees the offset addresses a valid device register.
+    unsafe fn read32(&self, off: usize) -> u32;
+    /// Read a `u8` at byte offset `off`.
+    ///
+    /// # Safety
+    /// See [`Mmio::read32`].
+    unsafe fn read8(&self, off: usize) -> u8;
+    /// Write a `u8` at byte offset `off`.
+    ///
+    /// # Safety
+    /// See [`Mmio::read32`]. Caller must ensure the offset is writable.
+    unsafe fn write8(&mut self, off: usize, val: u8);
+}
+
+/// Real-hardware MMIO backend wrapping a raw base pointer.
+pub struct RawMmio {
+    base: *mut u8,
+}
+
+impl RawMmio {
+    /// Wrap a raw MMIO base address.
+    ///
+    /// # Safety
+    /// `base` must point to a mapped PL011 device region of at least `0x40`
+    /// bytes, matching the SP manifest device-region attributes (R/W, device
+    /// memory).
+    pub unsafe fn new(base: usize) -> Self {
+        Self { base: base as *mut u8 }
+    }
+}
+
+impl Mmio for RawMmio {
+    unsafe fn read32(&self, off: usize) -> u32 {
+        // SAFETY: precondition of `RawMmio::new` — `base` is a mapped device
+        // region and `off` is within bounds.
+        unsafe { core::ptr::read_volatile(self.base.add(off) as *const u32) }
+    }
+    unsafe fn read8(&self, off: usize) -> u8 {
+        // SAFETY: same precondition as `read32`.
+        unsafe { core::ptr::read_volatile(self.base.add(off)) }
+    }
+    unsafe fn write8(&mut self, off: usize, val: u8) {
+        // SAFETY: same precondition as `read32`; `off` must be writable.
+        unsafe { core::ptr::write_volatile(self.base.add(off), val) }
+    }
+}
+
+// PL011 register offsets (relative to base). `pub` so test fixtures can
+// target the same offsets without redeclaring the magic numbers.
+pub const UARTDR: usize = 0x000;
+pub const UARTFR: usize = 0x018;
+
+// PL011 flag-register bits.
+pub const FR_RXFE: u32 = 1 << 4; // RX FIFO empty
+pub const FR_TXFF: u32 = 1 << 5; // TX FIFO full
+
+/// PL011 driver errors.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// Reserved for future bounded-poll variants. Currently unused by the
+    /// shipping methods (`write_bytes`, `read_byte_blocking`); kept for
+    /// API symmetry with the `Result` return types.
+    Timeout,
+}
+
+/// Blocking PL011 UART driver. Generic over the [`Mmio`] backend.
+pub struct Pl011Uart<M: Mmio> {
+    mmio: M,
+}
+
+impl<M: Mmio> Pl011Uart<M> {
+    /// Wrap an [`Mmio`] backend. Does NOT touch UARTCR / UARTLCR_H — TF-A
+    /// and QEMU init are assumed.
+    ///
+    /// Crate-private: external callers should use [`Pl011Uart::new`]
+    /// (production) or construct directly with `Pl011Uart { mmio }` in
+    /// tests (via the `pub(crate)` field).
+    pub(crate) const fn from_mmio(mmio: M) -> Self {
+        Self { mmio }
+    }
+
+    /// Borrow the underlying MMIO backend (test-only inspection helper).
+    #[cfg(test)]
+    pub(crate) fn mmio_for_test(&self) -> &M {
+        &self.mmio
+    }
+
+    /// Blocking write of a byte slice. Each byte polls `UARTFR.TXFF` until
+    /// clear, then writes `UARTDR`. Returns `Ok(())` (no error path; result
+    /// type included for API symmetry + future-proofing).
+    pub fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        for &b in bytes {
+            // SAFETY: `UARTFR` / `UARTDR` are in the device region passed to
+            // `RawMmio::new` (or the mock backend's tracked offsets in tests).
+            // The poll loop reads only; the write goes to the writable
+            // `UARTDR` offset.
+            unsafe {
+                while self.mmio.read32(UARTFR) & FR_TXFF != 0 {
+                    core::hint::spin_loop();
+                }
+                self.mmio.write8(UARTDR, b);
+            }
+        }
+        Ok(())
+    }
+
+    /// Unbounded blocking read of one byte. Busy-spins until
+    /// `UARTFR.RXFE` clears.
+    pub fn read_byte_blocking(&mut self) -> Result<u8, Error> {
+        loop {
+            // SAFETY: see `write_bytes`.
+            let fr = unsafe { self.mmio.read32(UARTFR) };
+            if fr & FR_RXFE == 0 {
+                // SAFETY: RXFE clear ⇒ at least one byte in the RX FIFO.
+                return Ok(unsafe { self.mmio.read8(UARTDR) });
+            }
+            core::hint::spin_loop();
+        }
+    }
+}
+
+impl Pl011Uart<RawMmio> {
+    /// Convenience constructor for the production MMIO backend.
+    ///
+    /// # Safety
+    /// Caller must have mapped the device region declared in
+    /// `qemu-ec-sp.dts` (`ec_uart`) at `base`; the SP manifest must grant
+    /// R/W access to at least `0x40` bytes there. `base` is `u64` per the
+    /// SBSA SP physical-address convention; cast to host pointer width
+    /// internally.
+    pub unsafe fn new(base: u64) -> Self {
+        // SAFETY: precondition propagated to caller per the function-level
+        // `# Safety` clause.
+        let mmio = unsafe { RawMmio::new(base as usize) };
+        Self::from_mmio(mmio)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host-side tests. `MockMmio` lives entirely under `#[cfg(test)]` — it does
+// NOT exist in the `aarch64-unknown-none[-softfloat]` binary, preserving the
+// no-alloc runtime.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::{Cell, RefCell};
+    use std::collections::VecDeque;
+    use std::vec;
+    use std::vec::Vec;
+
+    /// Scripted MMIO backend.
+    ///
+    /// `fr_script` is a queue of `UARTFR` values consumed in order; once
+    /// drained, every subsequent `read32(UARTFR)` returns `fr_default`.
+    /// `dr_rx_byte` is what `read8(UARTDR)` returns. `dr_tx_log` records
+    /// every `write8(UARTDR, _)` in order. `fr_read_count` lets tests
+    /// assert poll-loop iteration counts.
+    struct MockMmio {
+        fr_script: RefCell<VecDeque<u32>>,
+        fr_default: u32,
+        fr_read_count: Cell<u32>,
+        dr_rx_byte: u8,
+        dr_tx_log: RefCell<Vec<u8>>,
+    }
+
+    impl MockMmio {
+        fn new(fr_default: u32, dr_rx_byte: u8) -> Self {
+            Self {
+                fr_script: RefCell::new(VecDeque::new()),
+                fr_default,
+                fr_read_count: Cell::new(0),
+                dr_rx_byte,
+                dr_tx_log: RefCell::new(Vec::new()),
+            }
+        }
+        fn push_fr(&mut self, v: u32) {
+            self.fr_script.borrow_mut().push_back(v);
+        }
+        fn fr_read_count(&self) -> u32 {
+            self.fr_read_count.get()
+        }
+        fn dr_tx_log(&self) -> Vec<u8> {
+            self.dr_tx_log.borrow().clone()
+        }
+    }
+
+    impl Mmio for MockMmio {
+        unsafe fn read32(&self, off: usize) -> u32 {
+            assert_eq!(off, UARTFR, "MockMmio only models UARTFR for read32");
+            self.fr_read_count.set(self.fr_read_count.get() + 1);
+            self.fr_script.borrow_mut().pop_front().unwrap_or(self.fr_default)
+        }
+        unsafe fn read8(&self, off: usize) -> u8 {
+            assert_eq!(off, UARTDR);
+            self.dr_rx_byte
+        }
+        unsafe fn write8(&mut self, off: usize, val: u8) {
+            assert_eq!(off, UARTDR);
+            self.dr_tx_log.borrow_mut().push(val);
+        }
+    }
+
+    #[test]
+    fn write_bytes_writes_each_byte_in_order() {
+        let mock = MockMmio::new(0, 0); // TXFF clear by default → no waiting
+        let mut uart = Pl011Uart::from_mmio(mock);
+        uart.write_bytes(&[0x01, 0x02, 0x03]).expect("write");
+        assert_eq!(uart.mmio_for_test().dr_tx_log(), vec![0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn write_bytes_polls_txff_until_clear() {
+        let mut mock = MockMmio::new(0, 0);
+        mock.push_fr(FR_TXFF); // first poll: TX full
+        mock.push_fr(FR_TXFF); // second poll: still full
+        mock.push_fr(0); // third poll: clear → write
+        let mut uart = Pl011Uart::from_mmio(mock);
+        uart.write_bytes(&[0x42]).expect("write");
+        assert_eq!(uart.mmio_for_test().dr_tx_log(), vec![0x42]);
+        assert_eq!(uart.mmio_for_test().fr_read_count(), 3);
+    }
+
+    #[test]
+    fn read_byte_blocking_returns_byte_when_rxfe_clears() {
+        let mut mock = MockMmio::new(0, 0xAB); // FR default 0 = RXFE clear
+                                               // Push a couple of "RX still empty" reads first to confirm the loop polls:
+        mock.push_fr(FR_RXFE);
+        mock.push_fr(FR_RXFE);
+        // Then default 0 takes over → RXFE clear → read returns 0xAB.
+        let mut uart = Pl011Uart::from_mmio(mock);
+        assert_eq!(uart.read_byte_blocking().expect("read"), 0xAB);
+        assert!(uart.mmio_for_test().fr_read_count() >= 3);
+    }
+}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -25,258 +25,261 @@ criteria = "safe-to-deploy"
 version = "0.2.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.aho-corasick]]
+version = "1.1.4"
+criteria = "safe-to-run"
+
 [[exemptions.atomic]]
-version = "0.6.0"
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.autocfg]]
+version = "1.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitflags]]
-version = "2.9.4"
+version = "2.11.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bumpalo]]
-version = "3.17.0"
+version = "3.20.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytemuck]]
+version = "1.25.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.24"
+version = "1.2.62"
+criteria = "safe-to-deploy"
+
+[[exemptions.cfg-if]]
+version = "1.0.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]
-version = "0.4.19"
+version = "0.4.44"
 criteria = "safe-to-deploy"
 
-[[exemptions.critical-section]]
-version = "1.2.0"
+[[exemptions.crc]]
+version = "3.4.0"
 criteria = "safe-to-deploy"
+notes = "Used by mctp-rs `serial` feature (FCS-16 over PL011)."
 
-[[exemptions.darling]]
-version = "0.20.11"
+[[exemptions.crc-catalog]]
+version = "2.5.0"
 criteria = "safe-to-deploy"
-
-[[exemptions.darling_core]]
-version = "0.20.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.darling_macro]]
-version = "0.20.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-executor]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-executor-macros]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-executor-timer-queue]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-futures]]
-version = "0.1.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-sync]]
-version = "0.7.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-time]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-time-driver]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.embassy-time-queue-utils]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embedded-hal]]
-version = "0.2.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.embedded-hal]]
-version = "1.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.embedded-hal-async]]
-version = "1.0.0"
-criteria = "safe-to-deploy"
+notes = "crc transitive."
 
 [[exemptions.embedded-io]]
 version = "0.6.1"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
-[[exemptions.embedded-io-async]]
-version = "0.6.1"
+[[exemptions.find-msvc-tools]]
+version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.futures-core]]
-version = "0.3.31"
+version = "0.3.32"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-macro]]
+version = "0.3.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.futures-sink]]
-version = "0.3.31"
+version = "0.3.32"
+criteria = "safe-to-run"
+notes = "embassy-sync transitive."
+
+[[exemptions.futures-task]]
+version = "0.3.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.futures-timer]]
-version = "3.0.3"
+version = "3.0.4"
 criteria = "safe-to-run"
 
-[[exemptions.hash32]]
-version = "0.3.1"
+[[exemptions.futures-util]]
+version = "0.3.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.hashbrown]]
-version = "0.15.3"
+version = "0.17.1"
 criteria = "safe-to-run"
 
 [[exemptions.heapless]]
-version = "0.8.0"
+version = "0.9.3"
+criteria = "safe-to-run"
+notes = "Widely-used embedded crate (mctp-rs transitive resolution)."
+
+[[exemptions.heck]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.husky-rs]]
+version = "0.3.3"
+criteria = "safe-to-run"
+
+[[exemptions.iana-time-zone]]
+version = "0.1.65"
 criteria = "safe-to-deploy"
 
 [[exemptions.iana-time-zone-haiku]]
 version = "0.1.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.ident_case]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
+[[exemptions.indexmap]]
+version = "2.14.0"
+criteria = "safe-to-run"
 
 [[exemptions.js-sys]]
-version = "0.3.76"
+version = "0.3.99"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
-version = "0.2.172"
-criteria = "safe-to-deploy"
-
-[[exemptions.log]]
-version = "0.4.27"
+version = "0.2.186"
 criteria = "safe-to-deploy"
 
 [[exemptions.memchr]]
-version = "2.5.0"
+version = "2.8.0"
 criteria = "safe-to-run"
-
-[[exemptions.num_enum]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.num_enum_derive]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
 
 [[exemptions.once_cell]]
-version = "1.20.1"
+version = "1.21.4"
 criteria = "safe-to-deploy"
+
+[[exemptions.paste]]
+version = "1.0.15"
+criteria = "safe-to-run"
+notes = "Widely-used proc-macro (embedded-services dep)."
+
+[[exemptions.pin-project-lite]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.portable-atomic]]
+version = "1.13.1"
+criteria = "safe-to-run"
+notes = "Widely-used embedded crate (embassy-sync transitive)."
 
 [[exemptions.proc-macro-crate]]
-version = "3.3.0"
+version = "3.5.0"
 criteria = "safe-to-run"
 
-[[exemptions.proc-macro2]]
-version = "1.0.95"
-criteria = "safe-to-deploy"
-
-[[exemptions.rstest]]
-version = "0.26.1"
+[[exemptions.regex-syntax]]
+version = "0.8.10"
 criteria = "safe-to-run"
 
-[[exemptions.rstest_macros]]
-version = "0.26.1"
+[[exemptions.semver]]
+version = "1.0.28"
 criteria = "safe-to-run"
-
-[[exemptions.rustversion]]
-version = "1.0.21"
-criteria = "safe-to-deploy"
 
 [[exemptions.shlex]]
 version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.slab]]
-version = "0.4.9"
+version = "0.4.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.stable_deref_trait]]
+version = "1.2.1"
 criteria = "safe-to-run"
+notes = "heapless transitive."
 
 [[exemptions.subenum]]
-version = "1.1.2"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
-version = "1.0.109"
-criteria = "safe-to-deploy"
-
-[[exemptions.syn]]
-version = "2.0.100"
+version = "2.0.117"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.12"
+version = "2.0.18"
 criteria = "safe-to-deploy"
+notes = "mctp-rs dep."
 
 [[exemptions.thiserror-impl]]
-version = "2.0.12"
+version = "2.0.18"
 criteria = "safe-to-deploy"
+notes = "thiserror proc-macro transitive."
 
 [[exemptions.tock-registers]]
 version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_datetime]]
-version = "0.6.9"
+version = "1.1.1+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.toml_edit]]
-version = "0.22.26"
+version = "0.25.11+spec-1.1.0"
 criteria = "safe-to-run"
 
+[[exemptions.toml_parser]]
+version = "1.1.2+spec-1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.unicode-ident]]
+version = "1.0.24"
+criteria = "safe-to-deploy"
+
 [[exemptions.uuid]]
-version = "1.16.0"
+version = "1.23.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.99"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-backend]]
-version = "0.2.100"
+version = "0.2.122"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.99"
+version = "0.2.122"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.100"
+version = "0.2.122"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
-version = "0.2.100"
+version = "0.2.122"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-core]]
-version = "0.61.2"
+version = "0.62.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-implement]]
-version = "0.60.0"
+version = "0.60.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-interface]]
-version = "0.59.1"
+version = "0.59.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-link]]
+version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-result]]
-version = "0.3.4"
+version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-strings]]
-version = "0.4.2"
+version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.winnow]]
-version = "0.7.10"
+version = "1.0.3"
 criteria = "safe-to-run"
+
+[[exemptions.zerocopy]]
+version = "0.8.48"
+criteria = "safe-to-run"
+notes = "heapless transitive."
+
+[[exemptions.zerocopy-derive]]
+version = "0.8.48"
+criteria = "safe-to-run"
+notes = "zerocopy proc-macro transitive."

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,13 +1,238 @@
 
 # cargo-vet imports lock
 
-[audits.OpenDevicePartnership.audits]
+[[audits.OpenDevicePartnership.audits.bare-metal]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.5"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
 
-[[audits.google.audits.aho-corasick]]
-who = "Ying Hsu <yinghsu@chromium.org>"
+[[audits.OpenDevicePartnership.audits.bitfield]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.13.2"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.bitfield]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.2 -> 0.15.0"
+notes = "Delta audit: BitRange/Bit traits split into read-only and mutable variants (BitRangeMut/BitMut); added mask constant generation; clippy fixes; MSRV bump. No unsafe, no build script, no proc macros, no powerful imports. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.bitfield]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.0 -> 0.17.0"
+notes = "Delta: adds bitwise op derives, constructor derives, arbitrary visibility. Pure declarative macros. No unsafe, no build script. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.bitfield-struct]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.10.1"
+notes = "Proc-macro crate generating safe bitfield structs. No unsafe, no build script. Standard proc-macro deps only. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.bitfield-struct]]
+who = "matteotullo <matteotullo@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.1 -> 0.12.1"
+notes = "Adds hash and bitenum derives, mostly parsing and refactoring changes. No code execution nor writing to the filesystem."
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.cortex-m]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.7"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.critical-section]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embassy-futures]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+notes = "no_std future combinators. All unsafe is pin-projection and no-op RawWaker - reviewed and sound. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embassy-sync]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.8.0"
+notes = "no_std async sync primitives. Substantial unsafe for UnsafeCell-based interiors and Send/Sync impls -- all reviewed and sound, guarded by RawMutex/critical_section. Build script only reads TARGET env var. No proc macros, no powerful imports. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-batteries]]
+who = "matteotullo <matteotullo@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
+notes = "ODP crates are always trusted."
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-batteries-async]]
+who = "matteotullo <matteotullo@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
+notes = "ODP crates are always trusted."
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-crc-macros]]
+who = "Matteo Tullo <matteotullo@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-hal]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.7"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-hal]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.7 -> 1.0.0"
+notes = "Pure no_std trait crate. Complete API redesign for 1.0: removed nb-based traits, CAN module, all unsafe code. Only defines traits/enums/types for digital, I2C, SPI, PWM, delay. No build script, no proc macros, no powerful imports. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-io]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.1 -> 0.7.1"
+notes = "Add core::error::Error trait bound (MSRV 1.81). defmt 0.3->1.0. Implement ReadReady/WriteReady for slices and VecDeque. Add seek_relative(). Fix method forwardings. Trusted publisher (Dirbaio from Embedded WG)."
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-imxrt/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-io-async]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.6.1"
+notes = "No unsafe. Build script only detects nightly via rustc --version. Pure async trait definitions for embedded I/O. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.embedded-io-async]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.1 -> 0.7.0"
+notes = "Delta 0.6.1->0.7.0: No unsafe. Build script removed (AFIT now stable). flush() made required, BufRead requires Read, new VecDeque impls. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.glob]]
+who = "Billy Price <williamp@microsoft.com>"
 criteria = "safe-to-run"
-version = "1.1.3"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+delta = "0.3.2 -> 0.3.3"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.hash32]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+notes = "no_std 32-bit hashing (FNV, MurmurHash3). ~10 unsafe blocks in murmur3.rs for MaybeUninit buffer handling - all sound. Assisted-by: copilot-cli:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.num_enum]]
+who = "Billy Price <williamp@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.5"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-imxrt/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.num_enum]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.7.6"
+notes = "Version bump with test infrastructure updates. No unsafe code, no build script, no powerful imports. Purely additive test changes."
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.num_enum_derive]]
+who = "Billy Price <williamp@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.5"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-imxrt/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.num_enum_derive]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.7.6"
+notes = "Minor update adding byte literal support for enum discriminants. No unsafe code, no build script, no powerful imports."
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.rstest]]
+who = "Billy Price <williamp@microsoft.com>"
+criteria = "safe-to-run"
+delta = "0.22.0 -> 0.26.1"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.rstest_macros]]
+who = "Billy Price <williamp@microsoft.com>"
+criteria = "safe-to-run"
+delta = "0.22.0 -> 0.26.1"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.rustc_version]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.3"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.rustversion]]
+who = "Billy Price <williamp@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.20 -> 1.0.22"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-imxrt/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.semver]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.semver-parser]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.serde]]
+who = "Robert Zieba <robertzieba@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.228"
+notes = "Changes are mostly a reorganization of the internal module structure"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.serde_core]]
+who = "Robert Zieba <robertzieba@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.226"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.serde_derive]]
+who = "Robert Zieba <robertzieba@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.228"
+notes = "Diff is clean-up in proc macros"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.smbus-pec]]
+who = "Matteo Tullo <matteotullo@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.vcell]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.OpenDevicePartnership.audits.volatile-register]]
+who = "Felipe Balbi <felipe.balbi@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.2"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.google.audits.android_system_properties]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -16,86 +241,12 @@ version = "0.1.5"
 notes = "Android system API FFI"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.autocfg]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "1.4.0"
-notes = "Contains no unsafe"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.bytemuck]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.16.3"
-notes = """
-Review notes from the original audit (of 1.14.3) may be found in
-https://crrev.com/c/5362675.  Note that this audit has initially missed UB risk
-that was fixed in 1.16.2 - see https://github.com/Lokathor/bytemuck/pull/258.
-Because of this, the original audit has been edited to certify version `1.16.3`
-instead (see also https://crrev.com/c/5771867).
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.bytemuck]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.16.3 -> 1.17.1"
-notes = "Unsafe review comments can be found in https://crrev.com/c/5813463"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.bytemuck]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.17.1 -> 1.18.0"
-notes = "No code changes - just altering feature flag arrangements"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.bytemuck]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.18.0 -> 1.19.0"
-notes = "No code changes - just comment changes and adding the track_caller attribute."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.bytemuck]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.19.0 -> 1.20.0"
-notes = "`unsafe` review can be found at https://crrev.com/c/6096767"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.bytemuck]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.20.0 -> 1.21.0"
-notes = "Unsafe review at https://chromium-review.googlesource.com/c/chromium/src/+/6111154/"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.bytemuck]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.21.0 -> 1.22.0"
-notes = """
-This adds new instances of unsafe, but the uses are justified:
-- BoxBytes is essentially a Box<[u8], which is Send + Sync, so also marking BoxBytes as Send + Sync is justified.
-- core::num::Saturating<T> meets the criteria for Zeroable + Pod, so marking it as such is justified.
-
-See https://crrev.com/c/6321863 for more audit notes.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.byteorder]]
 who = "danakj <danakj@chromium.org>"
 criteria = "safe-to-deploy"
 version = "1.5.0"
 notes = "Unsafe review in https://crrev.com/c/5838022"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.cfg-if]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-deploy"
-version = "1.0.0"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.core-foundation-sys]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -117,49 +268,6 @@ delta = "1.0.1 -> 1.0.2"
 notes = "No changes to any .rs files or Rust code."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.futures-macro]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-version = "0.3.28"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.futures-macro]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-delta = "0.3.28 -> 0.3.31"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.futures-task]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-version = "0.3.28"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.futures-task]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-delta = "0.3.28 -> 0.3.31"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.futures-util]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-version = "0.3.28"
-notes = """
-There's a custom xorshift-based `random::shuffle` implementation in
-src/async_await/random.rs. This is `doc(hidden)` and seems to exist just so
-that `futures-macro::select` can be unbiased. Sicne xorshift is explicitly not
-intended to be a cryptographically secure algorithm, it is not considered
-crypto.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.futures-util]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-delta = "0.3.28 -> 0.3.31"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.glob]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -173,49 +281,30 @@ delta = "0.3.1 -> 0.3.2"
 notes = "Still no unsafe"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.heck]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
+[[audits.google.audits.log]]
+who = "danakj <danakj@chromium.org>"
 criteria = "safe-to-deploy"
-version = "0.4.1"
+version = "0.4.22"
 notes = """
-Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'``, `'\bnet\b'``, `'\bunsafe\b'``
-and there were no hits.
+Unsafe review in https://docs.google.com/document/d/1IXQbD1GhTRqNHIGxq6yy7qHqxeO4CwN5noMFXnqyDIM/edit?usp=sharing
 
-`heck` (version `0.3.3`) has been added to Chromium in
-https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
+Unsafety is generally very well-documented, with one exception, which we
+describe in the review doc.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.iana-time-zone]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "0.1.61"
-notes = "Some unsafe: interfacing with system timezone APIs"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.indexmap]]
+[[audits.google.audits.log]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-version = "2.7.1"
-notes = '''
-Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`
-and there were no hits.
-
-There is a little bit of `unsafe` Rust code - the audit can be found at
-https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
-'''
+delta = "0.4.22 -> 0.4.25"
+notes = "No impact on `unsafe` usage in `lib.rs`."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.indexmap]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
+[[audits.google.audits.log]]
+who = "Daniel Cheng <dcheng@chromium.org>"
 criteria = "safe-to-deploy"
-delta = "2.7.1 -> 2.8.0"
-notes = """
-No `unsafe` introduced or affected in:
-* `indexmap_with_default!` and `indexset_with_default!` macros
-* New `PartialEq` implementations
-* `fn slice_eq` in `util.rs`
-"""
+delta = "0.4.25 -> 0.4.26"
+notes = "Only trivial code and documentation changes."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.nb]]
@@ -243,25 +332,118 @@ version = "0.2.19"
 notes = "Contains a single line of float-to-int unsafe with decent safety comments"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.pin-project-lite]]
-who = "David Koloski <dkoloski@google.com>"
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-version = "0.2.9"
-notes = "Reviewed on https://fxrev.dev/824504"
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+version = "1.0.78"
+notes = """
+Grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
+(except for a benign \"fs\" hit in a doc comment)
 
-[[audits.google.audits.pin-project-lite]]
-who = "David Koloski <dkoloski@google.com>"
+Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
 criteria = "safe-to-deploy"
-delta = "0.2.9 -> 0.2.13"
-notes = "Audited at https://fxrev.dev/946396"
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+delta = "1.0.78 -> 1.0.79"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.pin-utils]]
-who = "Android Legacy"
-criteria = "safe-to-run"
-version = "0.1.0"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.79 -> 1.0.80"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.80 -> 1.0.81"
+notes = "Comment changes only"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.81 -> 1.0.82"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.82 -> 1.0.83"
+notes = "Substantive change is replacing String with Box<str>, saving memory."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.83 -> 1.0.84"
+notes = "Only doc comment changes in `src/lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.84 -> 1.0.85"
+notes = "Test-only changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.85 -> 1.0.86"
+notes = """
+Comment-only changes in `build.rs`.
+Reordering of `Cargo.toml` entries.
+Just bumping up the version number in `lib.rs`.
+Config-related changes in `test_size.rs`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.86 -> 1.0.87"
+notes = "No new unsafe interactions."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Liza Burakova <liza@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.87 -> 1.0.89"
+notes = """
+Biggest change is adding error handling in build.rs.
+Some config related changes in wrapper.rs.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.89 -> 1.0.92"
+notes = """
+I looked at the delta and the previous discussion at
+https://chromium-review.googlesource.com/c/chromium/src/+/5385745/3#message-a8e2813129fa3779dab15acede408ee26d67b7f3
+and the changes look okay to me (including the `unsafe fn from_str_unchecked`
+changes in `wrapper.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.92 -> 1.0.93"
+notes = "No `unsafe`-related changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.93 -> 1.0.94"
+notes = "Minor doc changes and clippy lint adjustments+fixes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
@@ -325,12 +507,6 @@ criteria = "safe-to-run"
 version = "0.4.9"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
-[[audits.google.audits.regex-syntax]]
-who = "Justin Green <greenjustin@google.com>"
-criteria = "safe-to-run"
-version = "0.8.5"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.relative-path]]
 who = "danakj <danakj@chromium.org>"
 criteria = "safe-to-deploy"
@@ -340,6 +516,37 @@ There is no net or fs usage, no crypto.
 There is unsafe to convert pointers from str to RelativePath, where the latter
 is a transparent wrapper around str so the pointer will be to a valid
 type/value always.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rstest]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.17.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rstest]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.17.0 -> 0.22.0"
+notes = "No new unsafe. fs and net usage, but only in its own tests."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rstest_macros]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-run"
+version = "0.22.0"
+notes = """
+There is no fs or net usage directly, though there is fs
+usage through the glob crate to get lists of files if the user
+asks for it in their macro.
+
+There is no unsafe. Scanned through all the code.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
@@ -361,61 +568,72 @@ delta = "0.4.0 -> 0.4.1"
 notes = "No unsafe, net or fs."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.semver]]
-who = "danakj@chromium.org"
-criteria = "safe-to-run"
-version = "1.0.20"
+[[audits.google.audits.rustversion]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.14"
 notes = """
-Reviewed in https://crrev.com/c/5171063
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'``, `'\bnet\b'``, `'\bunsafe\b'``
+and there were no hits except for:
 
-Previously reviewed during security review and the audit is grandparented in.
+* Using trivially-safe `unsafe` in test code:
+
+    ```
+    tests/test_const.rs:unsafe fn _unsafe() {}
+    tests/test_const.rs:const _UNSAFE: () = unsafe { _unsafe() };
+    ```
+
+* Using `unsafe` in a string:
+
+    ```
+    src/constfn.rs:            \"unsafe\" => Qualifiers::Unsafe,
+    ```
+
+* Using `std::fs` in `build/build.rs` to write `${OUT_DIR}/version.expr`
+  which is later read back via `include!` used in `src/lib.rs`.
+
+Version `1.0.6` of this crate has been added to Chromium in
+https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.semver]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-run"
-delta = "1.0.20 -> 1.0.21"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.semver]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-run"
-delta = "1.0.21 -> 1.0.22"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.semver]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-run"
-delta = "1.0.22 -> 1.0.23"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.semver]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-run"
-delta = "1.0.23 -> 1.0.24"
-notes = "Minor, `ptr_eq`-related changes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.semver]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-run"
-delta = "1.0.24 -> 1.0.25"
-notes = "No changes in `.rs` files except `doc` attribute changes in `lib.rs`."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.semver]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-run"
-delta = "1.0.25 -> 1.0.26"
-notes = "Only minor documentation updates."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.stable_deref_trait]]
-who = "Manish Goregaokar <manishearth@google.com>"
+[[audits.google.audits.rustversion]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
 criteria = "safe-to-deploy"
-version = "1.2.0"
-notes = "Purely a trait, crates using this should be carefully vetted since self-referential stuff can be super tricky around various unsafe rust edges."
+delta = "1.0.14 -> 1.0.15"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustversion]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.15 -> 1.0.16"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustversion]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.16 -> 1.0.17"
+notes = "Just updates windows compat"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustversion]]
+who = "Liza Burakova <liza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.17 -> 1.0.18"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustversion]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.18 -> 1.0.19"
+notes = "No unsafe, just doc changes"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustversion]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.19 -> 1.0.20"
+notes = "Only minor updates to documentation and the mock today used for testing."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.static_assertions]]
@@ -435,223 +653,56 @@ description contains a link to a document with an additional security review.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.strsim]]
-who = "danakj@chromium.org"
-criteria = "safe-to-deploy"
-version = "0.10.0"
-notes = """
-Reviewed in https://crrev.com/c/5171063
-
-Previously reviewed during security review and the audit is grandparented in.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.unicode-ident]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.0.12"
-notes = '''
-I grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits.
-
-All two functions from the public API of this crate use `unsafe` to avoid bound
-checks for an array access.  Cross-module analysis shows that the offsets can
-be statically proven to be within array bounds.  More details can be found in
-the unsafe review CL at https://crrev.com/c/5350386.
-
-This crate has been added to Chromium in https://crrev.com/c/3891618.
-'''
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.unicode-ident]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.12 -> 1.0.13"
-notes = "Lots of table updates, and tables are assumed correct with unsafe `.get_unchecked()`, so ub-risk-2 is appropriate"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.unicode-ident]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.13 -> 1.0.14"
-notes = "Minimal delta in `.rs` files: new test assertions + doc changes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.unicode-ident]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.14 -> 1.0.15"
-notes = "No changes relevant to any of these criteria."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.unicode-ident]]
-who = "Liza Burakova <liza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.15 -> 1.0.16"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.unicode-ident]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.16 -> 1.0.18"
-notes = "Only minor comment and documentation updates."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.void]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "1.0.2"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
-[[audits.mozilla.audits.android-tzdata]]
-who = "Mark Hammond <mhammond@skippinet.com.au>"
-criteria = "safe-to-deploy"
-version = "0.1.1"
-notes = "Small crate parsing a file. No unsafe code"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.chrono]]
-who = "Mark Hammond <mhammond@skippinet.com.au>"
-criteria = "safe-to-deploy"
-delta = "0.4.19 -> 0.4.40"
-notes = "Significant refactor of both implementation and dependencies."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.chrono]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.40 -> 0.4.41"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.document-features]]
+[[audits.mozilla.audits.log]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
-version = "0.2.8"
+delta = "0.4.26 -> 0.4.29"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.document-features]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.8 -> 0.2.9"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.document-features]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.9 -> 0.2.10"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.document-features]]
-who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.10 -> 0.2.11"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.fnv]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "1.0.7"
-notes = "Simple hasher implementation with no unsafe code."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.iana-time-zone]]
-who = "Mark Hammond <mhammond@skippinet.com.au>"
-criteria = "safe-to-deploy"
-delta = "0.1.61 -> 0.1.63"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.indexmap]]
+[[audits.mozilla.audits.proc-macro2]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
-delta = "2.8.0 -> 2.9.0"
-notes = "Doc update, a new API, one carefully annotated unsafe code block with all preconditions checked"
+delta = "1.0.94 -> 1.0.106"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.js-sys]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.76 -> 0.3.77"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.litrs]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.4.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.memchr]]
+[[audits.mozilla.audits.quote]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
-delta = "2.5.0 -> 2.7.4"
+delta = "1.0.40 -> 1.0.45"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.once_cell]]
+[[audits.mozilla.audits.regex]]
+who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.11.1 -> 1.12.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.regex-automata]]
+who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.9 -> 0.4.14"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_core]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "1.20.1 -> 1.20.2"
-notes = "This update works around a Cargo bug that forces the addition of `portable-atomic` into a lockfile, which we have never needed to use."
+delta = "1.0.226 -> 1.0.227"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.once_cell]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
+[[audits.mozilla.audits.serde_core]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
-delta = "1.20.2 -> 1.20.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.once_cell]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.20.3 -> 1.21.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.once_cell]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.21.1 -> 1.21.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.pin-project-lite]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.13 -> 0.2.14"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.pin-project-lite]]
-who = "Nika Layzell <nika@thelayzells.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.14 -> 0.2.16"
-notes = """
-Only functional change is to work around a bug in the negative_impls feature
-(https://github.com/taiki-e/pin-project/issues/340#issuecomment-2432146009)
-"""
-aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+delta = "1.0.227 -> 1.0.228"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.shlex]]
 who = "Max Inden <mail@max-inden.de>"
 criteria = "safe-to-deploy"
 delta = "1.1.0 -> 1.3.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.strsim]]
-who = "Ben Dean-Kawamura <bdk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.10.0 -> 0.11.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.wasm-bindgen]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.99 -> 0.2.100"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.wasm-bindgen-macro]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.99 -> 0.2.100"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.windows-link]]
-who = "Mark Hammond <mhammond@skippinet.com.au>"
-criteria = "safe-to-deploy"
-version = "0.1.1"
-notes = "A microsoft crate allowing unsafe calls to windows apis."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"


### PR DESCRIPTION
## Summary

Adds a Battery FFA service to the QEMU SBSA secure partition, backed by a real EC connection over PL011 UART using MCTP serial (DSP0253) framing.

### New crates
- **`sp-mctp-framer`** — Lightweight MCTP serial framing layer on top of `mctp-rs`. Handles DSP0253 byte-stuffing, CRC-16, and packet assembly/disassembly over a raw byte stream.
- **`qemu-sp-uart`** — Minimal PL011 MMIO UART driver for the secure partition (polled mode, no interrupts).

### Changes to existing crates
- **`qemu-sp`** — Wires up the new Battery FFA handler + EC relay pipeline: FFA request → MCTP serialize → PL011 TX → PL011 RX → MCTP deserialize → FFA response.

### Architecture
```
UEFI (NS) ──FFA──▶ SP (qemu-sp)
                      │
                      ├── BatteryFfaHandler
                      │     └── ec_relay::send_request()
                      │           ├── sp-mctp-framer::serialize
                      │           ├── qemu-sp-uart::write
                      │           ├── qemu-sp-uart::read
                      │           └── sp-mctp-framer::deserialize
                      │
                      └── PL011 UART ──serial──▶ EC (dev-qemu)
```
