### PR TITLE
Default Locality 0 and 1 to OPEN

### DIFF
--- a/ec-service-lib/src/services/tpm.rs
+++ b/ec-service-lib/src/services/tpm.rs
@@ -604,6 +604,11 @@ impl<S: TpmSstOps> TpmService<S> {
         self.locality_states[0] = TpmLocalityState::Open;
         self.locality_states[1] = TpmLocalityState::Open;
 
+        // Default all other localities to closed.
+        self.locality_states[2] = TpmLocalityState::Closed;
+        self.locality_states[3] = TpmLocalityState::Closed;
+        self.locality_states[4] = TpmLocalityState::Closed;
+
         // Initialize the TPM Service State Translation Library.
         self.sst.init(tpm_external_crb_address);
 
@@ -906,7 +911,7 @@ mod tests {
     // =======================================================================
     #[test]
     fn test_tpm_service_init() {
-        let (buff, addr) = alloc_crb_region();
+        let (_buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
         unsafe { service.init(addr, EXTERNAL_TPM_CRB_ADDR) };
         assert_eq!(
@@ -922,6 +927,9 @@ mod tests {
         assert_eq!(service.tpm_internal_crb_address, addr);
         assert_eq!(service.locality_states[0], TpmLocalityState::Open);
         assert_eq!(service.locality_states[1], TpmLocalityState::Open);
+        assert_eq!(service.locality_states[2], TpmLocalityState::Closed);
+        assert_eq!(service.locality_states[3], TpmLocalityState::Closed);
+        assert_eq!(service.locality_states[4], TpmLocalityState::Closed);
         assert_eq!(service.current_state, TpmState::Idle);
         assert_eq!(service.active_locality, NO_ACTIVE_LOCALITY);
     }
@@ -1019,7 +1027,7 @@ mod tests {
     // =======================================================================
     #[test]
     fn test_start_locality_request() {
-        let (buff, addr) = alloc_crb_region();
+        let (_buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
         unsafe { service.init(addr, EXTERNAL_TPM_CRB_ADDR) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };
@@ -1052,7 +1060,7 @@ mod tests {
 
     #[test]
     fn test_start_command() {
-        let (buff, addr) = alloc_crb_region();
+        let (_buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
         unsafe { service.init(addr, EXTERNAL_TPM_CRB_ADDR) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };
@@ -1128,7 +1136,7 @@ mod tests {
 
     #[test]
     fn test_start_locality_relinquish() {
-        let (buff, addr) = alloc_crb_region();
+        let (_buff, addr) = alloc_crb_region();
         let mut service = TpmService::new(MockTpmSst::new());
         unsafe { service.init(addr, EXTERNAL_TPM_CRB_ADDR) };
         let crb: &mut PtpCrbRegisters = unsafe { &mut (*service.crb_ptr(0)) };

--- a/ec-service-lib/src/services/tpm.rs
+++ b/ec-service-lib/src/services/tpm.rs
@@ -600,6 +600,10 @@ impl<S: TpmSstOps> TpmService<S> {
             self.init_internal_crb(locality);
         }
 
+        // Default Locality 0 and Locality 1 to open.
+        self.locality_states[0] = TpmLocalityState::Open;
+        self.locality_states[1] = TpmLocalityState::Open;
+
         // Initialize the TPM Service State Translation Library.
         self.sst.init(tpm_external_crb_address);
 
@@ -895,6 +899,31 @@ mod tests {
             [TpmLocalityState::Closed; NUM_LOCALITIES as usize],
         );
         assert_eq!(service.tpm_internal_crb_address, 0x10000200000);
+    }
+
+    // =======================================================================
+    // TpmService::init Test(s)
+    // =======================================================================
+    #[test]
+    fn test_tpm_service_init() {
+        let (buff, addr) = alloc_crb_region();
+        let mut service = TpmService::new(MockTpmSst::new());
+        unsafe { service.init(addr, EXTERNAL_TPM_CRB_ADDR) };
+        assert_eq!(
+            service.interface_id_default.interface_type(),
+            PtpCrbInterfaceType::Crb as u32
+        );
+        assert_eq!(
+            service.interface_id_default.interface_version(),
+            PtpCrbInterfaceVersion::Crb as u32
+        );
+        assert_eq!(service.interface_id_default.cap_locality(), 1); // 5 localities supported
+        assert_eq!(service.interface_id_default.cap_crb(), 1); // CRB supported
+        assert_eq!(service.tpm_internal_crb_address, addr);
+        assert_eq!(service.locality_states[0], TpmLocalityState::Open);
+        assert_eq!(service.locality_states[1], TpmLocalityState::Open);
+        assert_eq!(service.current_state, TpmState::Idle);
+        assert_eq!(service.active_locality, NO_ACTIVE_LOCALITY);
     }
 
     // =======================================================================


### PR DESCRIPTION
## Description

Defaulting Locality 0 and 1 to OPEN. This better aligns with how things normally are and doesn't require a trusted entity to open them for the TPM to work. Added a new UnitTest to test the TPM service internal variables after init to verify that the localities are set to OPEN.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

All UnitTests passing.

## Integration Instructions

N/A