### PR TITLE
feat(thermal): Thermal as an EC relay shim (GetTmp) + bounded read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "battery-service-interface"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
 dependencies = [
  "embedded-batteries-async",
 ]
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "battery-service-relay"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
 dependencies = [
  "battery-service-interface",
  "embedded-services",
@@ -236,6 +236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "ec-service-lib"
 version = "0.1.0"
 dependencies = [
@@ -248,6 +257,7 @@ dependencies = [
  "mctp-rs",
  "num_enum",
  "odp-ffa",
+ "thermal-service-relay",
  "uuid",
 ]
 
@@ -269,6 +279,31 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "heapless",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-core",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
+dependencies = [
+ "document-features",
 ]
 
 [[package]]
@@ -301,6 +336,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f1c75747a43b086df1a87fb2a889590bc0725e0abf54bba6d0c4bf7bd9e762c"
 
 [[package]]
+name = "embedded-fans"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5007eb97aabfe3606c0b02823b3120e861c748ed3560756aa4fd231ef9ebf0"
+
+[[package]]
+name = "embedded-fans-async"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafd19dc3b6aaa5027856818e19ccbfe84ebfb094c8a0ecf84a20e75c3b8e959"
+dependencies = [
+ "embedded-fans",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +365,15 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
+]
 
 [[package]]
 name = "embedded-io"
@@ -332,9 +391,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-sensors-hal"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c703756bee31e7aaf55d8fb6dcf7337cfc231cfb4a3ad34b9df509846fd9001"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "embedded-sensors-hal-async"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c524a78b2804eca0d9ec05154e51d9af948b40cd0a6bbcc4d5832ff7e47b5b"
+dependencies = [
+ "embedded-sensors-hal",
+ "paste",
+]
+
+[[package]]
 name = "embedded-services"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
 dependencies = [
  "bitfield 0.17.0",
  "cortex-m",
@@ -562,6 +640,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,7 +654,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 [[package]]
 name = "mctp-rs"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
 dependencies = [
  "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities)",
  "crc",
@@ -696,6 +780,7 @@ dependencies = [
  "hafnium",
  "log",
  "odp-ffa",
+ "qemu-sp-uart",
  "uuid",
 ]
 
@@ -911,6 +996,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "thermal-service-interface"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
+dependencies = [
+ "embassy-time",
+ "embedded-fans-async",
+ "embedded-sensors-hal-async",
+]
+
+[[package]]
+name = "thermal-service-relay"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
+dependencies = [
+ "embedded-services",
+ "num_enum",
+ "thermal-service-interface",
+ "uuid",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,9 +1080,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "atomic",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "battery-service-interface"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#0cadc205b55fe829df3c8cb3accb5cc565422ccc"
 dependencies = [
  "embedded-batteries-async",
 ]
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "battery-service-relay"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#0cadc205b55fe829df3c8cb3accb5cc565422ccc"
 dependencies = [
  "battery-service-interface",
  "embedded-services",
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "embedded-services"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#0cadc205b55fe829df3c8cb3accb5cc565422ccc"
 dependencies = [
  "bitfield 0.17.0",
  "cortex-m",
@@ -654,7 +654,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 [[package]]
 name = "mctp-rs"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#0cadc205b55fe829df3c8cb3accb5cc565422ccc"
 dependencies = [
  "bit-register 0.1.0 (git+https://github.com/OpenDevicePartnership/odp-utilities)",
  "crc",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "thermal-service-interface"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#0cadc205b55fe829df3c8cb3accb5cc565422ccc"
 dependencies = [
  "embassy-time",
  "embedded-fans-async",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "thermal-service-relay"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?rev=5cc395f101ad574214a49b2894c484cc19d41695#5cc395f101ad574214a49b2894c484cc19d41695"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services.git?branch=main#0cadc205b55fe829df3c8cb3accb5cc565422ccc"
 dependencies = [
  "embedded-services",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,11 @@ odp-ffa = { path = "odp-ffa" }
 hafnium = { path = "hafnium" }
 qemu-sp-uart = { path = "qemu-sp-uart" }
 
-mctp-rs = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false, features = ["serial"] }
-embedded-services = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false }
-battery-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false }
-battery-service-interface = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false }
-thermal-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false }
+mctp-rs = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false, features = ["serial"] }
+embedded-services = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
+battery-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
+battery-service-interface = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
+thermal-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
 embedded-io = { version = "0.7", default-features = false }
 log = { version = "0.4", default-features = false }
 mockall = "0.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,11 @@ odp-ffa = { path = "odp-ffa" }
 hafnium = { path = "hafnium" }
 qemu-sp-uart = { path = "qemu-sp-uart" }
 
-mctp-rs = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false, features = ["serial"] }
-embedded-services = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
-battery-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
-battery-service-interface = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", branch = "main", default-features = false }
+mctp-rs = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false, features = ["serial"] }
+embedded-services = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false }
+battery-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false }
+battery-service-interface = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false }
+thermal-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "5cc395f101ad574214a49b2894c484cc19d41695", default-features = false }
 embedded-io = { version = "0.7", default-features = false }
 log = { version = "0.4", default-features = false }
 mockall = "0.13.1"

--- a/ec-service-lib/Cargo.toml
+++ b/ec-service-lib/Cargo.toml
@@ -34,6 +34,7 @@ aarch64-cpu.workspace = true
 embedded-services.workspace = true
 battery-service-relay.workspace = true
 battery-service-interface.workspace = true
+thermal-service-relay.workspace = true
 
 [features]
 default = []

--- a/ec-service-lib/src/services/battery.rs
+++ b/ec-service-lib/src/services/battery.rs
@@ -244,5 +244,4 @@ mod tests {
         assert_eq!(result.battery_remaining_capacity, bst.battery_remaining_capacity);
         assert_eq!(result.battery_present_voltage, bst.battery_present_voltage);
     }
-
 }

--- a/ec-service-lib/src/services/battery.rs
+++ b/ec-service-lib/src/services/battery.rs
@@ -40,7 +40,7 @@ use core::cell::RefCell;
 
 use uuid::{uuid, Uuid};
 
-use crate::services::ec_relay::{self, EcRelayError, Relay};
+use crate::services::ec_relay::{EcRelayError, Relay};
 use crate::{Result, Service};
 use odp_ffa::{Error as FfaError, MsgSendDirectReq2, MsgSendDirectResp2};
 
@@ -110,26 +110,20 @@ impl<'r, R: Relay> Battery<'r, R> {
     /// MCTP relay. Returns the parsed BST body or a relay/wire-format
     /// error.
     pub fn get_bst(&self, battery_id: u8) -> core::result::Result<BstReturnRaw, BatteryError> {
-        let request_header = ec_relay::build_odp_header(true, BATTERY_SERVICE_ID, BATTERY_CMD_GET_BST);
-        let request_body = [battery_id];
-
         self.relay
             .borrow_mut()
-            .invoke(request_header, &request_body, |response| {
-                if response.service_id != BATTERY_SERVICE_ID || response.message_id != BATTERY_CMD_GET_BST {
-                    return Err(EcRelayError::UnexpectedOdpService);
-                }
-                if response.body.len() < GET_BST_RESPONSE_BODY_LEN {
-                    return Err(EcRelayError::BodyTooShort);
-                }
-                let payload = &response.body[..GET_BST_RESPONSE_BODY_LEN];
-                Ok(BstReturnRaw {
+            .invoke_request(
+                BATTERY_SERVICE_ID,
+                BATTERY_CMD_GET_BST,
+                &[battery_id],
+                GET_BST_RESPONSE_BODY_LEN,
+                |payload| BstReturnRaw {
                     battery_state: u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]),
                     battery_present_rate: u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]),
                     battery_remaining_capacity: u32::from_le_bytes([payload[8], payload[9], payload[10], payload[11]]),
                     battery_present_voltage: u32::from_le_bytes([payload[12], payload[13], payload[14], payload[15]]),
-                })
-            })
+                },
+            )
             .map_err(BatteryError::Relay)
     }
 }
@@ -180,8 +174,8 @@ extern crate std;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::ec_relay::test_util::{frame_response_packets, LoopbackTransport};
-    use crate::services::ec_relay::EcRelay;
+    use crate::services::ec_relay::test_util::{frame_response_packets, strip_mctp_framing, LoopbackTransport};
+    use crate::services::ec_relay::{self, EcRelay};
     use battery_service_interface::{BatteryState, BstReturn};
     use battery_service_relay::{AcpiBatteryRequest, AcpiBatteryResponse};
     use embedded_services::relay::SerializableMessage;
@@ -251,18 +245,4 @@ mod tests {
         assert_eq!(result.battery_present_voltage, bst.battery_present_voltage);
     }
 
-    /// Strip MCTP serial framing from the bytes Battery emitted on TX.
-    /// Returns the inner body (post the MCTP-message-type byte): 4 bytes
-    /// of OdpHeader + N bytes of serialized payload.
-    fn strip_mctp_framing(framed: &[u8]) -> std::vec::Vec<u8> {
-        use mctp_rs::{MctpPacketContext, MctpSerialMedium};
-        let mut buf = [0u8; 256];
-        let mut ctx = MctpPacketContext::<MctpSerialMedium>::new(MctpSerialMedium, &mut buf);
-        let message = ctx
-            .deserialize_packet(framed)
-            .expect("deserialize_packet ok")
-            .expect("complete message");
-        assert_eq!(message.message_buffer.message_type(), ec_relay::ODP_MESSAGE_TYPE);
-        message.message_buffer.body().to_vec()
-    }
 }

--- a/ec-service-lib/src/services/ec_relay.rs
+++ b/ec-service-lib/src/services/ec_relay.rs
@@ -151,6 +151,11 @@ pub enum EcRelayError {
     TransportWrite,
     /// Transport-layer read failure (UART RX timeout, etc.).
     TransportRead,
+    /// Transport-layer read budget exhausted (EC did not produce a
+    /// framed response within the bounded poll budget). Distinct
+    /// from `TransportRead` so callers can surface a deterministic
+    /// FFA reply (e.g. `status: -1`) rather than retrying.
+    TransportReadTimeout,
     /// `MctpPacketContext::serialize_packet` failed.
     MctpSerialize(&'static str),
     /// Bytes received from transport could not be parsed as a complete
@@ -220,9 +225,14 @@ impl<U: embedded_io::Read + embedded_io::Write> OdpTransport for MctpSerialTrans
                 return Err(EcRelayError::MctpRecvIncomplete);
             }
             let mut byte = [0u8; 1];
-            self.uart
-                .read_exact(&mut byte)
-                .map_err(|_| EcRelayError::TransportRead)?;
+            self.uart.read_exact(&mut byte).map_err(|e| match e {
+                embedded_io::ReadExactError::Other(inner)
+                    if embedded_io::Error::kind(&inner) == embedded_io::ErrorKind::TimedOut =>
+                {
+                    EcRelayError::TransportReadTimeout
+                }
+                _ => EcRelayError::TransportRead,
+            })?;
             buf[filled] = byte[0];
             filled += 1;
             if byte[0] == SERIAL_END_FLAG {
@@ -480,6 +490,47 @@ pub(crate) mod test_util {
         }
     }
 
+    /// Test-only UART that always reports a timed-out read. Used to
+    /// exercise the `MctpSerialTransport::recv_framed_packet`
+    /// error-mapping path.
+    pub struct TimeoutUart;
+
+    impl embedded_io::ErrorType for TimeoutUart {
+        type Error = TimeoutUartErr;
+    }
+
+    #[derive(Debug)]
+    pub struct TimeoutUartErr;
+
+    impl embedded_io::Error for TimeoutUartErr {
+        fn kind(&self) -> embedded_io::ErrorKind {
+            embedded_io::ErrorKind::TimedOut
+        }
+    }
+
+    impl core::fmt::Display for TimeoutUartErr {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "timeout")
+        }
+    }
+
+    impl core::error::Error for TimeoutUartErr {}
+
+    impl embedded_io::Read for TimeoutUart {
+        fn read(&mut self, _buf: &mut [u8]) -> Result<usize, Self::Error> {
+            Err(TimeoutUartErr)
+        }
+    }
+
+    impl embedded_io::Write for TimeoutUart {
+        fn write(&mut self, _buf: &[u8]) -> Result<usize, Self::Error> {
+            Ok(0)
+        }
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
     /// Helper used by per-service tests: synthesize a framed response
     /// packet from `(response_header, response_body)` by running the
     /// EC-side framing path (TX from EC_EID to SP_EID).
@@ -525,5 +576,16 @@ mod tests {
     #[test]
     fn parse_odp_header_rejects_short_buffer() {
         assert!(parse_odp_header(&[0x02, 0x08, 0x00]).is_err());
+    }
+
+    #[test]
+    fn recv_framed_packet_maps_timed_out_kind_to_transport_read_timeout() {
+        use test_util::TimeoutUart;
+        let mut t = MctpSerialTransport::new(TimeoutUart);
+        let mut buf = [0u8; 64];
+        let err = t
+            .recv_framed_packet(&mut buf)
+            .expect_err("timeout should surface");
+        assert_eq!(err, EcRelayError::TransportReadTimeout);
     }
 }

--- a/ec-service-lib/src/services/ec_relay.rs
+++ b/ec-service-lib/src/services/ec_relay.rs
@@ -151,10 +151,8 @@ pub enum EcRelayError {
     TransportWrite,
     /// Transport-layer read failure (UART RX timeout, etc.).
     TransportRead,
-    /// Transport-layer read budget exhausted (EC did not produce a
-    /// framed response within the bounded poll budget). Distinct
-    /// from `TransportRead` so callers can surface a deterministic
-    /// FFA reply (e.g. `status: -1`) rather than retrying.
+    /// Read budget exhausted before a framed response arrived. Distinct
+    /// from `TransportRead` so callers can fail deterministically.
     TransportReadTimeout,
     /// `MctpPacketContext::serialize_packet` failed.
     MctpSerialize(&'static str),
@@ -287,13 +285,9 @@ pub trait Relay {
     where
         F: FnOnce(OdpResponse<'_>) -> Result<R, EcRelayError>;
 
-    /// Issue a request to `service_id`/`message_id` and validate the
-    /// response envelope before parsing: the response must echo the same
-    /// service + message id and carry at least `min_body_len` bytes. The
-    /// parser receives a validated slice of exactly `min_body_len` bytes
-    /// and never re-checks the envelope or length. Collapses the
-    /// build-header → invoke → validate boilerplate every relay-backed
-    /// FFA service repeats per command.
+    /// Build the request header, invoke, and validate the response
+    /// envelope (same service + message id, at least `min_body_len`
+    /// bytes) before handing the parser a `min_body_len`-byte slice.
     fn invoke_request<R, F>(
         &mut self,
         service_id: u8,
@@ -497,10 +491,7 @@ pub(crate) mod test_util {
         }
     }
 
-    /// Strip MCTP serial framing from the bytes a service emitted on TX.
-    /// Returns the inner body (post the MCTP message-type byte): the
-    /// 4-byte ODP header followed by the serialized payload. Shared by
-    /// the per-service wire-format gate tests.
+    /// Strip MCTP framing; returns the inner body (ODP header + payload).
     pub fn strip_mctp_framing(framed: &[u8]) -> Vec<u8> {
         use mctp_rs::{MctpPacketContext, MctpSerialMedium};
         let mut buf = [0u8; 256];
@@ -536,9 +527,7 @@ pub(crate) mod test_util {
         }
     }
 
-    /// Test-only UART that always reports a timed-out read. Used to
-    /// exercise the `MctpSerialTransport::recv_framed_packet`
-    /// error-mapping path.
+    /// Test UART that always reports a timed-out read.
     pub struct TimeoutUart;
 
     impl embedded_io::ErrorType for TimeoutUart {
@@ -570,9 +559,8 @@ pub(crate) mod test_util {
 
     impl embedded_io::Write for TimeoutUart {
         fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-            // Swallow writes so callers exercising the full `invoke()`
-            // round-trip can reach the RX-side timeout path. Without
-            // this, `embedded_io::write_all` panics on `Ok(0)`.
+            // Swallow writes so tests reach the RX timeout path
+            // (`write_all` panics on `Ok(0)`).
             Ok(buf.len())
         }
         fn flush(&mut self) -> Result<(), Self::Error> {
@@ -632,9 +620,7 @@ mod tests {
         use test_util::TimeoutUart;
         let mut t = MctpSerialTransport::new(TimeoutUart);
         let mut buf = [0u8; 64];
-        let err = t
-            .recv_framed_packet(&mut buf)
-            .expect_err("timeout should surface");
+        let err = t.recv_framed_packet(&mut buf).expect_err("timeout should surface");
         assert_eq!(err, EcRelayError::TransportReadTimeout);
     }
 }

--- a/ec-service-lib/src/services/ec_relay.rs
+++ b/ec-service-lib/src/services/ec_relay.rs
@@ -523,8 +523,11 @@ pub(crate) mod test_util {
     }
 
     impl embedded_io::Write for TimeoutUart {
-        fn write(&mut self, _buf: &[u8]) -> Result<usize, Self::Error> {
-            Ok(0)
+        fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            // Swallow writes so callers exercising the full `invoke()`
+            // round-trip can reach the RX-side timeout path. Without
+            // this, `embedded_io::write_all` panics on `Ok(0)`.
+            Ok(buf.len())
         }
         fn flush(&mut self) -> Result<(), Self::Error> {
             Ok(())

--- a/ec-service-lib/src/services/ec_relay.rs
+++ b/ec-service-lib/src/services/ec_relay.rs
@@ -286,6 +286,36 @@ pub trait Relay {
     ) -> Result<R, EcRelayError>
     where
         F: FnOnce(OdpResponse<'_>) -> Result<R, EcRelayError>;
+
+    /// Issue a request to `service_id`/`message_id` and validate the
+    /// response envelope before parsing: the response must echo the same
+    /// service + message id and carry at least `min_body_len` bytes. The
+    /// parser receives a validated slice of exactly `min_body_len` bytes
+    /// and never re-checks the envelope or length. Collapses the
+    /// build-header → invoke → validate boilerplate every relay-backed
+    /// FFA service repeats per command.
+    fn invoke_request<R, F>(
+        &mut self,
+        service_id: u8,
+        message_id: u16,
+        request_body: &[u8],
+        min_body_len: usize,
+        parse_body: F,
+    ) -> Result<R, EcRelayError>
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        let request_header = build_odp_header(true, service_id, message_id);
+        self.invoke(request_header, request_body, |response| {
+            if response.service_id != service_id || response.message_id != message_id {
+                return Err(EcRelayError::UnexpectedOdpService);
+            }
+            if response.body.len() < min_body_len {
+                return Err(EcRelayError::BodyTooShort);
+            }
+            Ok(parse_body(&response.body[..min_body_len]))
+        })
+    }
 }
 
 /// Owning relay handle to the EC firmware over an `OdpTransport`. Owns
@@ -465,6 +495,22 @@ pub(crate) mod test_util {
         pub fn prime_rx<I: IntoIterator<Item = u8>>(&mut self, bytes: I) {
             self.rx.extend(bytes);
         }
+    }
+
+    /// Strip MCTP serial framing from the bytes a service emitted on TX.
+    /// Returns the inner body (post the MCTP message-type byte): the
+    /// 4-byte ODP header followed by the serialized payload. Shared by
+    /// the per-service wire-format gate tests.
+    pub fn strip_mctp_framing(framed: &[u8]) -> Vec<u8> {
+        use mctp_rs::{MctpPacketContext, MctpSerialMedium};
+        let mut buf = [0u8; 256];
+        let mut ctx = MctpPacketContext::<MctpSerialMedium>::new(MctpSerialMedium, &mut buf);
+        let message = ctx
+            .deserialize_packet(framed)
+            .expect("deserialize_packet ok")
+            .expect("complete message");
+        assert_eq!(message.message_buffer.message_type(), ODP_MESSAGE_TYPE);
+        message.message_buffer.body().to_vec()
     }
 
     impl OdpTransport for LoopbackTransport {

--- a/ec-service-lib/src/services/thermal.rs
+++ b/ec-service-lib/src/services/thermal.rs
@@ -1,36 +1,8 @@
-//! `Thermal` — FFA service that proxies Normal-World Thermal requests
-//! to the EC's `ThermalServiceRelayHandler` over MCTP.
+//! `Thermal` — FFA service that relays Normal-World Thermal requests to
+//! the EC over MCTP. Mirrors [`crate::services::battery::Battery`].
 //!
-//! Mirrors [`crate::services::battery::Battery`] exactly — see that file
-//! for the canonical pattern (generic `<'r, R: Relay>` shape,
-//! `&RefCell<R>` sharing of a single physical EC channel, manual
-//! SP-side serialization rationale, and the wire-format gate test).
-//!
-//! # Wire format (must match the EC's `OdpRelayHandler` byte-for-byte)
-//!
-//! Thermal service id = `0x09`; command discriminants follow
-//! `embedded-services/thermal-service-relay/src/serialization.rs::ThermalCmd`
-//! (`GetTmp = 1`, `SetThrs = 2`, `GetThrs = 3`, `SetScp = 4`,
-//! `GetVar = 5`, `SetVar = 6`).
-//!
-//! T2 (this commit) relays `GetTmp` only:
-//!
-//! Request body (post OdpHeader): `[instance_id: u8]` (1 byte).
-//! Response body (post OdpHeader): `[temperature: u32 LE DeciKelvin]` (4 bytes).
-//!
-//! The other five commands return `odp_ffa::Error::Other(..)` for now;
-//! T3 wires them on top of this shape.
-//!
-//! # SP-side runtime serialization is manual
-//!
-//! `embedded_services::relay::SerializableMessage` does not compile for
-//! `aarch64-unknown-none-softfloat` (the SBSA SP target) because
-//! `embassy-sync::ThreadModeRawMutex` is `cortex_m`-gated. As a
-//! workaround, SP-side runtime serialization is performed MANUALLY
-//! (1-byte request payload; 4 LE bytes for the GetTmp response). The
-//! wire-format gate test in the `tests` module below round-trips bytes
-//! through the EC's OWN `SerializableMessage` impl (via
-//! `[dev-dependencies]`) so any drift fails the build.
+//! Service id `0x09`; commands `GetTmp=1, SetThrs=2, GetThrs=3, SetScp=4,
+//! GetVar=5, SetVar=6`. Only `GetTmp` is relayed so far.
 
 use core::cell::RefCell;
 
@@ -40,14 +12,8 @@ use crate::services::ec_relay::{EcRelayError, Relay};
 use crate::{Result, Service};
 use odp_ffa::{DirectMessagePayload, Error as FfaError, HasRegisterPayload, MsgSendDirectReq2, MsgSendDirectResp2};
 
-/// ODP service-id for Thermal (matches the EC `OdpRelayHandler`
-/// instantiation in `embedded-services::thermal-service-relay`).
 pub const THERMAL_SERVICE_ID: u8 = 0x09;
 
-/// `ThermalCmd` discriminants from
-/// `embedded-services/thermal-service-relay/src/serialization.rs`. The
-/// enum itself is private to the EC crate; we mirror the integer
-/// constants here.
 pub const THERMAL_CMD_GET_TMP: u16 = 1;
 pub const THERMAL_CMD_SET_THRS: u16 = 2;
 pub const THERMAL_CMD_GET_THRS: u16 = 3;
@@ -55,16 +21,11 @@ pub const THERMAL_CMD_SET_SCP: u16 = 4;
 pub const THERMAL_CMD_GET_VAR: u16 = 5;
 pub const THERMAL_CMD_SET_VAR: u16 = 6;
 
-/// Body of a `GetTmp` response, post-OdpHeader (4 LE bytes / one u32 DeciKelvin).
 pub const GET_TMP_RESPONSE_BODY_LEN: usize = 4;
 
-/// Errors returned by [`Thermal::get_temperature`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThermalError {
-    /// Relay (MCTP + transport) failure — see [`EcRelayError`].
     Relay(EcRelayError),
-    /// EC's response was not a Thermal service response or not the
-    /// expected message id.
     UnexpectedResponse,
 }
 
@@ -74,9 +35,7 @@ impl From<EcRelayError> for ThermalError {
     }
 }
 
-/// FFA reply for `GetTmp`. `temp` is `u32 DeciKelvin` zero-extended
-/// to `u64`. `status: -1` indicates relay failure (matches the
-/// existing in-SP mock's reply shape that Normal-World callers expect).
+/// FFA reply for `GetTmp` (`temp` = EC u32 DeciKelvin; `status: -1` on relay failure).
 #[derive(Default, Debug, Clone, Copy)]
 struct TempRsp {
     status: i64,
@@ -89,11 +48,6 @@ impl From<TempRsp> for DirectMessagePayload {
     }
 }
 
-/// `Thermal` holds a handle to a shared [`Relay`] — it owns no
-/// transport, no assembly buffer, no MCTP framing state. Construction
-/// takes only a borrow of the wiring-layer-owned `RefCell<R>`. Mirrors
-/// [`crate::services::battery::Battery`] field-for-field; see that
-/// type's doc-comment for the rationale of generic `R: Relay`.
 pub struct Thermal<'r, R: Relay> {
     relay: &'r RefCell<R>,
 }
@@ -103,9 +57,7 @@ impl<'r, R: Relay> Thermal<'r, R> {
         Self { relay }
     }
 
-    /// Drive a single GetTmp request/response round-trip over the EC
-    /// MCTP relay. Returns the raw `u32 DeciKelvin` or a relay /
-    /// wire-format error.
+    /// Relay a GetTmp round-trip; returns the EC's `u32` DeciKelvin.
     pub fn get_temperature(&self, instance_id: u8) -> core::result::Result<u32, ThermalError> {
         self.relay
             .borrow_mut()
@@ -142,27 +94,16 @@ impl<R: Relay> Service for Thermal<'_, R> {
                     DirectMessagePayload::from(rsp),
                 ))
             }
-            // T3 will relay these five commands to the EC. For now they
-            // surface as a structured FFA error so the dispatch match
-            // stays exhaustive and the in-SP mock behavior is gone.
-            THERMAL_CMD_SET_THRS
-            | THERMAL_CMD_GET_THRS
-            | THERMAL_CMD_SET_SCP
-            | THERMAL_CMD_GET_VAR
+            // The other five commands are relayed in a follow-up.
+            THERMAL_CMD_SET_THRS | THERMAL_CMD_GET_THRS | THERMAL_CMD_SET_SCP | THERMAL_CMD_GET_VAR
             | THERMAL_CMD_SET_VAR => Err(FfaError::Other("thermal: command not yet relayed")),
             _ => Err(FfaError::Other("Unknown Thermal Command")),
         }
     }
 }
 
-// ===========================================================================
-// Wire-format compatibility gate
-//
-// Round-trips bytes through the EC's OWN `SerializableMessage::serialize` /
-// `deserialize` impls from `embedded-services/thermal-service-relay`. Any
-// drift in field order, endianness, or discriminant numbering causes the
-// assertion to fail. Runs on host (std available) — no QEMU.
-// ===========================================================================
+// Wire-format gate: round-trips bytes through the EC's own serializer so
+// any drift fails the build.
 
 #[cfg(test)]
 extern crate std;
@@ -170,15 +111,16 @@ extern crate std;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::ec_relay::test_util::{frame_response_packets, strip_mctp_framing, LoopbackTransport, TimeoutUart};
+    use crate::services::ec_relay::test_util::{
+        frame_response_packets, strip_mctp_framing, LoopbackTransport, TimeoutUart,
+    };
     use crate::services::ec_relay::{self, EcRelay, MctpSerialTransport};
     use embedded_services::relay::SerializableMessage;
     use thermal_service_relay::{DeciKelvin, ThermalRequest, ThermalResponse};
 
     #[test]
     fn produces_canonical_get_tmp_request_bytes() {
-        // -- Synthesize a canonical EC response: GetTmp body = u32 LE
-        //    DeciKelvin. 2982 dK ≈ 25.05 °C.
+        // EC GetTmp response: 2982 dK ≈ 25 °C.
         let mut response_payload = [0u8; GET_TMP_RESPONSE_BODY_LEN];
         let n = ThermalResponse::ThermalGetTmpResponse {
             temperature: DeciKelvin(2982),
@@ -190,20 +132,15 @@ mod tests {
         let response_header = ec_relay::build_odp_header(false, THERMAL_SERVICE_ID, THERMAL_CMD_GET_TMP);
         let framed_response = frame_response_packets(response_header, &response_payload);
 
-        // -- Construct the shared EcRelay (wrapping a loopback transport)
-        //    and hand a borrow to the Thermal service.
         let mut transport = LoopbackTransport::new();
         transport.prime_rx(framed_response.iter().copied());
         let relay = RefCell::new(EcRelay::new(transport));
         let svc = Thermal::new(&relay);
 
-        // -- Drive the round-trip.
         let dk = svc.get_temperature(0x07).expect("relay GetTmp");
         assert_eq!(dk, 2982);
 
-        // -- ASSERT 1 (request side, byte-level):
-        //    Thermal's TX bytes (MCTP-framed) decode back to exactly:
-        //      OdpHeader [0x02, 0x09, 0x00, 0x01]  +  payload [0x07]
+        // Request bytes: OdpHeader [0x02, 0x09, 0x00, 0x01] + payload [0x07].
         let tx_bytes = relay.borrow().transport().tx.clone();
         let inner_tx = strip_mctp_framing(&tx_bytes);
         assert_eq!(
@@ -212,17 +149,13 @@ mod tests {
             "Thermal GetTmp request wire bytes must match the EC's expected encoding exactly"
         );
 
-        // -- ASSERT 2 (round-trip via the EC's OWN deserializer):
-        //    The bytes Thermal produced parse back to
-        //    GetTmpRequest { instance_id: 0x07 } via
-        //    `ThermalRequest::deserialize`.
-        let (is_req, svc_id, _is_err, msg_id) =
-            ec_relay::parse_odp_header(&inner_tx[..4]).expect("parse header");
+        // The SP-produced bytes parse back via the EC's own deserializer.
+        let (is_req, svc_id, _is_err, msg_id) = ec_relay::parse_odp_header(&inner_tx[..4]).expect("parse header");
         assert!(is_req, "must be a request");
         assert_eq!(svc_id, THERMAL_SERVICE_ID);
         assert_eq!(msg_id, THERMAL_CMD_GET_TMP);
-        let decoded = ThermalRequest::deserialize(msg_id, &inner_tx[4..])
-            .expect("ec-side decoder must accept SP-produced bytes");
+        let decoded =
+            ThermalRequest::deserialize(msg_id, &inner_tx[4..]).expect("ec-side decoder must accept SP-produced bytes");
         assert!(
             matches!(decoded, ThermalRequest::ThermalGetTmpRequest { instance_id: 0x07 }),
             "EC-side decoder must reconstruct the original request variant"

--- a/ec-service-lib/src/services/thermal.rs
+++ b/ec-service-lib/src/services/thermal.rs
@@ -107,7 +107,7 @@ impl<R: Relay> Service for Thermal<'_, R> {
             | ThermalCommand::GetThrs
             | ThermalCommand::SetScp
             | ThermalCommand::GetVar
-            | ThermalCommand::SetVar => Err(FfaError::Other("thermal: command not yet relayed")),
+            | ThermalCommand::SetVar => Err(FfaError::Other("Thermal command not yet relayed")),
         }
     }
 }

--- a/ec-service-lib/src/services/thermal.rs
+++ b/ec-service-lib/src/services/thermal.rs
@@ -36,7 +36,7 @@ use core::cell::RefCell;
 
 use uuid::{uuid, Uuid};
 
-use crate::services::ec_relay::{self, EcRelayError, Relay};
+use crate::services::ec_relay::{EcRelayError, Relay};
 use crate::{Result, Service};
 use odp_ffa::{DirectMessagePayload, Error as FfaError, HasRegisterPayload, MsgSendDirectReq2, MsgSendDirectResp2};
 
@@ -107,21 +107,15 @@ impl<'r, R: Relay> Thermal<'r, R> {
     /// MCTP relay. Returns the raw `u32 DeciKelvin` or a relay /
     /// wire-format error.
     pub fn get_temperature(&self, instance_id: u8) -> core::result::Result<u32, ThermalError> {
-        let request_header = ec_relay::build_odp_header(true, THERMAL_SERVICE_ID, THERMAL_CMD_GET_TMP);
-        let request_body = [instance_id];
-
         self.relay
             .borrow_mut()
-            .invoke(request_header, &request_body, |response| {
-                if response.service_id != THERMAL_SERVICE_ID || response.message_id != THERMAL_CMD_GET_TMP {
-                    return Err(EcRelayError::UnexpectedOdpService);
-                }
-                if response.body.len() < GET_TMP_RESPONSE_BODY_LEN {
-                    return Err(EcRelayError::BodyTooShort);
-                }
-                let payload = &response.body[..GET_TMP_RESPONSE_BODY_LEN];
-                Ok(u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]))
-            })
+            .invoke_request(
+                THERMAL_SERVICE_ID,
+                THERMAL_CMD_GET_TMP,
+                &[instance_id],
+                GET_TMP_RESPONSE_BODY_LEN,
+                |payload| u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]),
+            )
             .map_err(ThermalError::Relay)
     }
 }
@@ -176,26 +170,10 @@ extern crate std;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::ec_relay::test_util::{frame_response_packets, LoopbackTransport, TimeoutUart};
-    use crate::services::ec_relay::{EcRelay, MctpSerialTransport};
+    use crate::services::ec_relay::test_util::{frame_response_packets, strip_mctp_framing, LoopbackTransport, TimeoutUart};
+    use crate::services::ec_relay::{self, EcRelay, MctpSerialTransport};
     use embedded_services::relay::SerializableMessage;
     use thermal_service_relay::{DeciKelvin, ThermalRequest, ThermalResponse};
-
-    /// Strip MCTP serial framing from the bytes Thermal emitted on TX.
-    /// Returns the inner body (post the MCTP-message-type byte): 4 bytes
-    /// of OdpHeader + N bytes of serialized payload. Verbatim copy of
-    /// `battery.rs::tests::strip_mctp_framing`.
-    fn strip_mctp_framing(framed: &[u8]) -> std::vec::Vec<u8> {
-        use mctp_rs::{MctpPacketContext, MctpSerialMedium};
-        let mut buf = [0u8; 256];
-        let mut ctx = MctpPacketContext::<MctpSerialMedium>::new(MctpSerialMedium, &mut buf);
-        let message = ctx
-            .deserialize_packet(framed)
-            .expect("deserialize_packet ok")
-            .expect("complete message");
-        assert_eq!(message.message_buffer.message_type(), ec_relay::ODP_MESSAGE_TYPE);
-        message.message_buffer.body().to_vec()
-    }
 
     #[test]
     fn produces_canonical_get_tmp_request_bytes() {

--- a/ec-service-lib/src/services/thermal.rs
+++ b/ec-service-lib/src/services/thermal.rs
@@ -14,12 +14,17 @@ use odp_ffa::{DirectMessagePayload, Error as FfaError, HasRegisterPayload, MsgSe
 
 pub const THERMAL_SERVICE_ID: u8 = 0x09;
 
-pub const THERMAL_CMD_GET_TMP: u16 = 1;
-pub const THERMAL_CMD_SET_THRS: u16 = 2;
-pub const THERMAL_CMD_GET_THRS: u16 = 3;
-pub const THERMAL_CMD_SET_SCP: u16 = 4;
-pub const THERMAL_CMD_GET_VAR: u16 = 5;
-pub const THERMAL_CMD_SET_VAR: u16 = 6;
+/// Thermal command ids (FFA request byte 0 / ODP message id).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[repr(u16)]
+pub enum ThermalCommand {
+    GetTmp = 1,
+    SetThrs = 2,
+    GetThrs = 3,
+    SetScp = 4,
+    GetVar = 5,
+    SetVar = 6,
+}
 
 pub const GET_TMP_RESPONSE_BODY_LEN: usize = 4;
 
@@ -63,7 +68,7 @@ impl<'r, R: Relay> Thermal<'r, R> {
             .borrow_mut()
             .invoke_request(
                 THERMAL_SERVICE_ID,
-                THERMAL_CMD_GET_TMP,
+                ThermalCommand::GetTmp.into(),
                 &[instance_id],
                 GET_TMP_RESPONSE_BODY_LEN,
                 |payload| u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]),
@@ -78,9 +83,12 @@ impl<R: Relay> Service for Thermal<'_, R> {
 
     fn ffa_msg_send_direct_req2(&mut self, msg: MsgSendDirectReq2) -> Result<MsgSendDirectResp2> {
         let cmd = msg.payload().u8_at(0);
+        let Ok(command) = ThermalCommand::try_from(cmd as u16) else {
+            return Err(FfaError::Other("Unknown Thermal Command"));
+        };
 
-        match cmd as u16 {
-            THERMAL_CMD_GET_TMP => {
+        match command {
+            ThermalCommand::GetTmp => {
                 let instance_id = msg.payload().u8_at(1);
                 let rsp = match self.get_temperature(instance_id) {
                     Ok(dk) => TempRsp {
@@ -95,9 +103,11 @@ impl<R: Relay> Service for Thermal<'_, R> {
                 ))
             }
             // The other five commands are relayed in a follow-up.
-            THERMAL_CMD_SET_THRS | THERMAL_CMD_GET_THRS | THERMAL_CMD_SET_SCP | THERMAL_CMD_GET_VAR
-            | THERMAL_CMD_SET_VAR => Err(FfaError::Other("thermal: command not yet relayed")),
-            _ => Err(FfaError::Other("Unknown Thermal Command")),
+            ThermalCommand::SetThrs
+            | ThermalCommand::GetThrs
+            | ThermalCommand::SetScp
+            | ThermalCommand::GetVar
+            | ThermalCommand::SetVar => Err(FfaError::Other("thermal: command not yet relayed")),
         }
     }
 }
@@ -129,7 +139,7 @@ mod tests {
         .expect("ec-side serialize");
         assert_eq!(n, GET_TMP_RESPONSE_BODY_LEN, "GetTmp response body must be 4 bytes");
 
-        let response_header = ec_relay::build_odp_header(false, THERMAL_SERVICE_ID, THERMAL_CMD_GET_TMP);
+        let response_header = ec_relay::build_odp_header(false, THERMAL_SERVICE_ID, ThermalCommand::GetTmp.into());
         let framed_response = frame_response_packets(response_header, &response_payload);
 
         let mut transport = LoopbackTransport::new();
@@ -153,7 +163,7 @@ mod tests {
         let (is_req, svc_id, _is_err, msg_id) = ec_relay::parse_odp_header(&inner_tx[..4]).expect("parse header");
         assert!(is_req, "must be a request");
         assert_eq!(svc_id, THERMAL_SERVICE_ID);
-        assert_eq!(msg_id, THERMAL_CMD_GET_TMP);
+        assert_eq!(msg_id, u16::from(ThermalCommand::GetTmp));
         let decoded =
             ThermalRequest::deserialize(msg_id, &inner_tx[4..]).expect("ec-side decoder must accept SP-produced bytes");
         assert!(

--- a/ec-service-lib/src/services/thermal.rs
+++ b/ec-service-lib/src/services/thermal.rs
@@ -1,29 +1,83 @@
-use crate::service::Service;
-use crate::Result;
-use log::{debug, error};
-use odp_ffa::{DirectMessagePayload, Function, HasRegisterPayload, MsgSendDirectReq2, MsgSendDirectResp2, Yield};
-use uuid::{uuid, Builder, Uuid};
+//! `Thermal` — FFA service that proxies Normal-World Thermal requests
+//! to the EC's `ThermalServiceRelayHandler` over MCTP.
+//!
+//! Mirrors [`crate::services::battery::Battery`] exactly — see that file
+//! for the canonical pattern (generic `<'r, R: Relay>` shape,
+//! `&RefCell<R>` sharing of a single physical EC channel, manual
+//! SP-side serialization rationale, and the wire-format gate test).
+//!
+//! # Wire format (must match the EC's `OdpRelayHandler` byte-for-byte)
+//!
+//! Thermal service id = `0x09`; command discriminants follow
+//! `embedded-services/thermal-service-relay/src/serialization.rs::ThermalCmd`
+//! (`GetTmp = 1`, `SetThrs = 2`, `GetThrs = 3`, `SetScp = 4`,
+//! `GetVar = 5`, `SetVar = 6`).
+//!
+//! T2 (this commit) relays `GetTmp` only:
+//!
+//! Request body (post OdpHeader): `[instance_id: u8]` (1 byte).
+//! Response body (post OdpHeader): `[temperature: u32 LE DeciKelvin]` (4 bytes).
+//!
+//! The other five commands return `odp_ffa::Error::Other(..)` for now;
+//! T3 wires them on top of this shape.
+//!
+//! # SP-side runtime serialization is manual
+//!
+//! `embedded_services::relay::SerializableMessage` does not compile for
+//! `aarch64-unknown-none-softfloat` (the SBSA SP target) because
+//! `embassy-sync::ThreadModeRawMutex` is `cortex_m`-gated. As a
+//! workaround, SP-side runtime serialization is performed MANUALLY
+//! (1-byte request payload; 4 LE bytes for the GetTmp response). The
+//! wire-format gate test in the `tests` module below round-trips bytes
+//! through the EC's OWN `SerializableMessage` impl (via
+//! `[dev-dependencies]`) so any drift fails the build.
 
-// Protocol CMD definitions for Thermal
-const EC_THM_GET_TMP: u8 = 0x1;
-const EC_THM_SET_THRS: u8 = 0x2;
-const EC_THM_GET_THRS: u8 = 0x3;
-const EC_THM_SET_SCP: u8 = 0x4;
-const EC_THM_GET_VAR: u8 = 0x5;
-const EC_THM_SET_VAR: u8 = 0x6;
+use core::cell::RefCell;
 
-#[derive(Default)]
-struct GenericRsp {
-    status: i64,
+use uuid::{uuid, Uuid};
+
+use crate::services::ec_relay::{self, EcRelayError, Relay};
+use crate::{Result, Service};
+use odp_ffa::{DirectMessagePayload, Error as FfaError, HasRegisterPayload, MsgSendDirectReq2, MsgSendDirectResp2};
+
+/// ODP service-id for Thermal (matches the EC `OdpRelayHandler`
+/// instantiation in `embedded-services::thermal-service-relay`).
+pub const THERMAL_SERVICE_ID: u8 = 0x09;
+
+/// `ThermalCmd` discriminants from
+/// `embedded-services/thermal-service-relay/src/serialization.rs`. The
+/// enum itself is private to the EC crate; we mirror the integer
+/// constants here.
+pub const THERMAL_CMD_GET_TMP: u16 = 1;
+pub const THERMAL_CMD_SET_THRS: u16 = 2;
+pub const THERMAL_CMD_GET_THRS: u16 = 3;
+pub const THERMAL_CMD_SET_SCP: u16 = 4;
+pub const THERMAL_CMD_GET_VAR: u16 = 5;
+pub const THERMAL_CMD_SET_VAR: u16 = 6;
+
+/// Body of a `GetTmp` response, post-OdpHeader (4 LE bytes / one u32 DeciKelvin).
+pub const GET_TMP_RESPONSE_BODY_LEN: usize = 4;
+
+/// Errors returned by [`Thermal::get_temperature`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThermalError {
+    /// Relay (MCTP + transport) failure — see [`EcRelayError`].
+    Relay(EcRelayError),
+    /// EC's response was not a Thermal service response or not the
+    /// expected message id.
+    UnexpectedResponse,
 }
 
-impl From<GenericRsp> for DirectMessagePayload {
-    fn from(value: GenericRsp) -> Self {
-        DirectMessagePayload::from_iter(value.status.to_le_bytes())
+impl From<EcRelayError> for ThermalError {
+    fn from(e: EcRelayError) -> Self {
+        ThermalError::Relay(e)
     }
 }
 
-#[derive(Default)]
+/// FFA reply for `GetTmp`. `temp` is `u32 DeciKelvin` zero-extended
+/// to `u64`. `status: -1` indicates relay failure (matches the
+/// existing in-SP mock's reply shape that Normal-World callers expect).
+#[derive(Default, Debug, Clone, Copy)]
 struct TempRsp {
     status: i64,
     temp: u64,
@@ -35,181 +89,174 @@ impl From<TempRsp> for DirectMessagePayload {
     }
 }
 
-#[derive(Default)]
-struct ThresholdReq {
-    id: u8,
-    timeout: u32,
-    low_temp: u32,
-    high_temp: u32,
+/// `Thermal` holds a handle to a shared [`Relay`] — it owns no
+/// transport, no assembly buffer, no MCTP framing state. Construction
+/// takes only a borrow of the wiring-layer-owned `RefCell<R>`. Mirrors
+/// [`crate::services::battery::Battery`] field-for-field; see that
+/// type's doc-comment for the rationale of generic `R: Relay`.
+pub struct Thermal<'r, R: Relay> {
+    relay: &'r RefCell<R>,
 }
-impl From<&DirectMessagePayload> for ThresholdReq {
-    fn from(msg: &DirectMessagePayload) -> ThresholdReq {
-        ThresholdReq {
-            id: msg.u8_at(1),
-            timeout: msg.u16_at(3) as u32,
-            low_temp: msg.u32_at(5),
-            high_temp: msg.u32_at(9),
-        }
+
+impl<'r, R: Relay> Thermal<'r, R> {
+    pub fn new(relay: &'r RefCell<R>) -> Self {
+        Self { relay }
     }
-}
 
-#[derive(Default)]
-struct ReadVarReq {
-    id: u8,
-    len: u16,
-    var_uuid: Uuid,
-}
+    /// Drive a single GetTmp request/response round-trip over the EC
+    /// MCTP relay. Returns the raw `u32 DeciKelvin` or a relay /
+    /// wire-format error.
+    pub fn get_temperature(&self, instance_id: u8) -> core::result::Result<u32, ThermalError> {
+        let request_header = ec_relay::build_odp_header(true, THERMAL_SERVICE_ID, THERMAL_CMD_GET_TMP);
+        let request_body = [instance_id];
 
-impl From<ReadVarReq> for DirectMessagePayload {
-    fn from(value: ReadVarReq) -> Self {
-        let iter = value
-            .id
-            .to_le_bytes()
-            .into_iter()
-            .chain(value.len.to_le_bytes())
-            .chain(value.var_uuid.as_bytes().iter().copied());
-
-        DirectMessagePayload::from_iter(iter)
-    }
-}
-
-impl From<&DirectMessagePayload> for ReadVarReq {
-    fn from(msg: &DirectMessagePayload) -> ReadVarReq {
-        ReadVarReq {
-            id: msg.u8_at(1),
-            len: msg.u16_at(2),
-            var_uuid: Builder::from_slice_le(msg.slice(4..20)).unwrap().into_uuid(),
-        }
+        self.relay
+            .borrow_mut()
+            .invoke(request_header, &request_body, |response| {
+                if response.service_id != THERMAL_SERVICE_ID || response.message_id != THERMAL_CMD_GET_TMP {
+                    return Err(EcRelayError::UnexpectedOdpService);
+                }
+                if response.body.len() < GET_TMP_RESPONSE_BODY_LEN {
+                    return Err(EcRelayError::BodyTooShort);
+                }
+                let payload = &response.body[..GET_TMP_RESPONSE_BODY_LEN];
+                Ok(u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]))
+            })
+            .map_err(ThermalError::Relay)
     }
 }
 
-#[derive(Default)]
-struct ReadVarRsp {
-    status: i64,
-    data: u32,
-}
-
-impl From<ReadVarRsp> for DirectMessagePayload {
-    fn from(value: ReadVarRsp) -> Self {
-        DirectMessagePayload::from_iter(value.status.to_le_bytes().into_iter().chain(value.data.to_le_bytes()))
-    }
-}
-
-#[derive(Default)]
-struct SetVarReq {
-    id: u8,
-    len: u16,
-    var_uuid: Uuid,
-    data: u32,
-}
-
-impl From<&DirectMessagePayload> for SetVarReq {
-    fn from(msg: &DirectMessagePayload) -> SetVarReq {
-        SetVarReq {
-            id: msg.u8_at(1),
-            len: msg.u16_at(2),
-            var_uuid: Builder::from_slice_le(msg.slice(4..20)).unwrap().into_uuid(),
-            data: msg.u32_at(20),
-        }
-    }
-}
-
-#[derive(Default)]
-pub struct Thermal {}
-
-impl Thermal {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn get_temperature(&self, msg: &MsgSendDirectReq2) -> TempRsp {
-        debug!("get_temperature sensor 0x{:x}", msg.payload().u8_at(1));
-
-        // Tell OS to delay 1 ms
-        Yield::new(0x100000000).exec().unwrap();
-
-        TempRsp {
-            status: 0x0,
-            temp: 0x1234,
-        }
-    }
-
-    fn set_threshold(&self, msg: &MsgSendDirectReq2) -> GenericRsp {
-        let req: ThresholdReq = msg.payload().into();
-        debug!(
-            "set_threshold temperature sensor 0x{:x}
-                Timeout: 0x{:x}
-                LowThreshold: 0x{:x}
-                HighThreshold: 0x{:x}",
-            req.id, req.timeout, req.low_temp, req.high_temp
-        );
-
-        GenericRsp { status: 0x0 }
-    }
-
-    fn get_threshold(&self, _msg: &MsgSendDirectReq2) -> GenericRsp {
-        GenericRsp { status: 0x0 }
-    }
-
-    fn set_cooling_policy(&self, _msg: &MsgSendDirectReq2) -> GenericRsp {
-        GenericRsp { status: 0x0 }
-    }
-
-    fn get_variable(&self, msg: &MsgSendDirectReq2) -> ReadVarRsp {
-        let req: ReadVarReq = msg.payload().into();
-        debug!(
-            "get_variable instance id: 0x{:x}
-                length: 0x{:x}
-                uuid: {}",
-            req.id, req.len, req.var_uuid
-        );
-
-        // Only support DWORD customized IO for now
-        if req.len != 4 {
-            error!("get_variable only supports DWORD read")
-        }
-
-        ReadVarRsp {
-            status: 0x0,
-            data: 0xdeadbeef,
-        }
-    }
-
-    fn set_variable(&self, msg: &MsgSendDirectReq2) -> GenericRsp {
-        let req: SetVarReq = msg.payload().into();
-        debug!(
-            "get_variable instance id: 0x{:x}
-                length: 0x{:x}
-                uuid: {}
-                data: 0x{:x}",
-            req.id, req.len, req.var_uuid, req.data
-        );
-
-        GenericRsp { status: 0x0 }
-    }
-}
-
-impl Service for Thermal {
+impl<R: Relay> Service for Thermal<'_, R> {
     const UUID: Uuid = uuid!("31f56da7-593c-4d72-a4b3-8fc7171ac073");
     const NAME: &'static str = "Thermal";
 
     fn ffa_msg_send_direct_req2(&mut self, msg: MsgSendDirectReq2) -> Result<MsgSendDirectResp2> {
         let cmd = msg.payload().u8_at(0);
-        debug!("Received ThmMgmt command 0x{:x}", cmd);
 
-        let payload = match cmd {
-            EC_THM_GET_TMP => DirectMessagePayload::from(self.get_temperature(&msg)),
-            EC_THM_SET_THRS => DirectMessagePayload::from(self.set_threshold(&msg)),
-            EC_THM_GET_THRS => DirectMessagePayload::from(self.get_threshold(&msg)),
-            EC_THM_SET_SCP => DirectMessagePayload::from(self.set_cooling_policy(&msg)),
-            EC_THM_GET_VAR => DirectMessagePayload::from(self.get_variable(&msg)),
-            EC_THM_SET_VAR => DirectMessagePayload::from(self.set_variable(&msg)),
-            _ => {
-                error!("Unknown Thermal Command: {}", cmd);
-                return Err(odp_ffa::Error::Other("Unknown Thermal Command"));
+        match cmd as u16 {
+            THERMAL_CMD_GET_TMP => {
+                let instance_id = msg.payload().u8_at(1);
+                let rsp = match self.get_temperature(instance_id) {
+                    Ok(dk) => TempRsp {
+                        status: 0,
+                        temp: dk as u64,
+                    },
+                    Err(_) => TempRsp { status: -1, temp: 0 },
+                };
+                Ok(MsgSendDirectResp2::from_req_with_payload(
+                    &msg,
+                    DirectMessagePayload::from(rsp),
+                ))
             }
-        };
+            // T3 will relay these five commands to the EC. For now they
+            // surface as a structured FFA error so the dispatch match
+            // stays exhaustive and the in-SP mock behavior is gone.
+            THERMAL_CMD_SET_THRS
+            | THERMAL_CMD_GET_THRS
+            | THERMAL_CMD_SET_SCP
+            | THERMAL_CMD_GET_VAR
+            | THERMAL_CMD_SET_VAR => Err(FfaError::Other("thermal: command not yet relayed")),
+            _ => Err(FfaError::Other("Unknown Thermal Command")),
+        }
+    }
+}
 
-        Ok(MsgSendDirectResp2::from_req_with_payload(&msg, payload))
+// ===========================================================================
+// Wire-format compatibility gate
+//
+// Round-trips bytes through the EC's OWN `SerializableMessage::serialize` /
+// `deserialize` impls from `embedded-services/thermal-service-relay`. Any
+// drift in field order, endianness, or discriminant numbering causes the
+// assertion to fail. Runs on host (std available) — no QEMU.
+// ===========================================================================
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::ec_relay::test_util::{frame_response_packets, LoopbackTransport, TimeoutUart};
+    use crate::services::ec_relay::{EcRelay, MctpSerialTransport};
+    use embedded_services::relay::SerializableMessage;
+    use thermal_service_relay::{DeciKelvin, ThermalRequest, ThermalResponse};
+
+    /// Strip MCTP serial framing from the bytes Thermal emitted on TX.
+    /// Returns the inner body (post the MCTP-message-type byte): 4 bytes
+    /// of OdpHeader + N bytes of serialized payload. Verbatim copy of
+    /// `battery.rs::tests::strip_mctp_framing`.
+    fn strip_mctp_framing(framed: &[u8]) -> std::vec::Vec<u8> {
+        use mctp_rs::{MctpPacketContext, MctpSerialMedium};
+        let mut buf = [0u8; 256];
+        let mut ctx = MctpPacketContext::<MctpSerialMedium>::new(MctpSerialMedium, &mut buf);
+        let message = ctx
+            .deserialize_packet(framed)
+            .expect("deserialize_packet ok")
+            .expect("complete message");
+        assert_eq!(message.message_buffer.message_type(), ec_relay::ODP_MESSAGE_TYPE);
+        message.message_buffer.body().to_vec()
+    }
+
+    #[test]
+    fn produces_canonical_get_tmp_request_bytes() {
+        // -- Synthesize a canonical EC response: GetTmp body = u32 LE
+        //    DeciKelvin. 2982 dK ≈ 25.05 °C.
+        let mut response_payload = [0u8; GET_TMP_RESPONSE_BODY_LEN];
+        let n = ThermalResponse::ThermalGetTmpResponse {
+            temperature: DeciKelvin(2982),
+        }
+        .serialize(&mut response_payload)
+        .expect("ec-side serialize");
+        assert_eq!(n, GET_TMP_RESPONSE_BODY_LEN, "GetTmp response body must be 4 bytes");
+
+        let response_header = ec_relay::build_odp_header(false, THERMAL_SERVICE_ID, THERMAL_CMD_GET_TMP);
+        let framed_response = frame_response_packets(response_header, &response_payload);
+
+        // -- Construct the shared EcRelay (wrapping a loopback transport)
+        //    and hand a borrow to the Thermal service.
+        let mut transport = LoopbackTransport::new();
+        transport.prime_rx(framed_response.iter().copied());
+        let relay = RefCell::new(EcRelay::new(transport));
+        let svc = Thermal::new(&relay);
+
+        // -- Drive the round-trip.
+        let dk = svc.get_temperature(0x07).expect("relay GetTmp");
+        assert_eq!(dk, 2982);
+
+        // -- ASSERT 1 (request side, byte-level):
+        //    Thermal's TX bytes (MCTP-framed) decode back to exactly:
+        //      OdpHeader [0x02, 0x09, 0x00, 0x01]  +  payload [0x07]
+        let tx_bytes = relay.borrow().transport().tx.clone();
+        let inner_tx = strip_mctp_framing(&tx_bytes);
+        assert_eq!(
+            inner_tx,
+            std::vec![0x02, 0x09, 0x00, 0x01, 0x07],
+            "Thermal GetTmp request wire bytes must match the EC's expected encoding exactly"
+        );
+
+        // -- ASSERT 2 (round-trip via the EC's OWN deserializer):
+        //    The bytes Thermal produced parse back to
+        //    GetTmpRequest { instance_id: 0x07 } via
+        //    `ThermalRequest::deserialize`.
+        let (is_req, svc_id, _is_err, msg_id) =
+            ec_relay::parse_odp_header(&inner_tx[..4]).expect("parse header");
+        assert!(is_req, "must be a request");
+        assert_eq!(svc_id, THERMAL_SERVICE_ID);
+        assert_eq!(msg_id, THERMAL_CMD_GET_TMP);
+        let decoded = ThermalRequest::deserialize(msg_id, &inner_tx[4..])
+            .expect("ec-side decoder must accept SP-produced bytes");
+        assert!(
+            matches!(decoded, ThermalRequest::ThermalGetTmpRequest { instance_id: 0x07 }),
+            "EC-side decoder must reconstruct the original request variant"
+        );
+    }
+
+    #[test]
+    fn get_temperature_surfaces_transport_read_timeout_as_relay_err() {
+        let transport = MctpSerialTransport::new(TimeoutUart);
+        let relay = RefCell::new(EcRelay::new(transport));
+        let svc = Thermal::new(&relay);
+        let err = svc.get_temperature(0).expect_err("timeout should propagate");
+        assert_eq!(err, ThermalError::Relay(EcRelayError::TransportReadTimeout));
     }
 }

--- a/platform/ihv1-sp/src/main.rs
+++ b/platform/ihv1-sp/src/main.rs
@@ -26,8 +26,13 @@ fn main() -> ! {
     let version = odp_ffa::Version::new().exec().unwrap();
     log::info!("FFA version: {}.{}", version.major(), version.minor());
 
+    // NOTE: the prior `ec_service_lib::services::Thermal` was a
+    // hardcoded-mock service. T2 replaced it with a relay-backed shim
+    // that needs a UART-backed `EcRelay` to construct. `ihv1-sp` has
+    // no UART driver wired in, so the (functionally no-op) Thermal
+    // append is removed for now. Wiring a real EcRelay here is a
+    // follow-up task for the IHV1 platform.
     MessageHandler::new()
-        .append(ec_service_lib::services::Thermal::new())
         .run_message_loop()
         .expect("Error in run_message_loop");
 

--- a/platform/ihv1-sp/src/main.rs
+++ b/platform/ihv1-sp/src/main.rs
@@ -27,11 +27,11 @@ fn main() -> ! {
     log::info!("FFA version: {}.{}", version.major(), version.minor());
 
     // NOTE: the prior `ec_service_lib::services::Thermal` was a
-    // hardcoded-mock service. T2 replaced it with a relay-backed shim
-    // that needs a UART-backed `EcRelay` to construct. `ihv1-sp` has
-    // no UART driver wired in, so the (functionally no-op) Thermal
-    // append is removed for now. Wiring a real EcRelay here is a
-    // follow-up task for the IHV1 platform.
+    // hardcoded-mock service; it is now a relay-backed shim that needs
+    // a UART-backed `EcRelay` to construct. `ihv1-sp` has no UART
+    // driver wired in, so the (functionally no-op) Thermal append is
+    // removed for now. Wiring a real EcRelay here is a follow-up for
+    // the IHV1 platform.
     MessageHandler::new()
         .run_message_loop()
         .expect("Error in run_message_loop");

--- a/platform/qemu-sp/Cargo.toml
+++ b/platform/qemu-sp/Cargo.toml
@@ -18,6 +18,7 @@ aarch64-paging.workspace = true
 aarch64-cpu.workspace = true
 aarch64-haf.workspace = true
 hafnium.workspace = true
+qemu-sp-uart.workspace = true
 
 [dependencies]
 odp-ffa.workspace = true

--- a/platform/qemu-sp/linker/qemu-ec-sp.dts
+++ b/platform/qemu-sp/linker/qemu-ec-sp.dts
@@ -90,14 +90,15 @@
 			attributes = <0x3>;
 		};
 
-		/* EC uart */
-		/*
+		/* EC uart — secure PL011 exposed by QEMU virt,secure=on @ 0x09040000.
+		 * Mapped into the SP so Pl011Uart::new(0x09040000) in main.rs can
+		 * drive the EC transport.
+		 */
 		ec_uart {
 			description = "ec uart";
 			base-address = <0x0 0x09040000>;
 			pages-count = <0x1>;
 			attributes = <0x3>;
 		};
-		*/
 	};
 };

--- a/platform/qemu-sp/linker/qemu-ec-sp.dts
+++ b/platform/qemu-sp/linker/qemu-ec-sp.dts
@@ -90,10 +90,7 @@
 			attributes = <0x3>;
 		};
 
-		/* EC uart — secure PL011 exposed by QEMU virt,secure=on @ 0x09040000.
-		 * Mapped into the SP so Pl011Uart::new(0x09040000) in main.rs can
-		 * drive the EC transport.
-		 */
+		/* EC uart — secure PL011 @ 0x09040000 (the EC MCTP link). */
 		ec_uart {
 			description = "ec uart";
 			base-address = <0x0 0x09040000>;

--- a/platform/qemu-sp/src/main.rs
+++ b/platform/qemu-sp/src/main.rs
@@ -19,7 +19,9 @@ fn main() {
 
 #[cfg(target_os = "none")]
 fn main() -> ! {
+    use core::cell::RefCell;
     use ec_service_lib::MessageHandler;
+    use ec_service_lib::services::{EcRelay, MctpSerialTransport, Thermal};
     use odp_ffa::Function;
 
     log::info!("QEMU Secure Partition - build time: {}", env!("BUILD_TIME"));
@@ -27,8 +29,20 @@ fn main() -> ! {
     let version = odp_ffa::Version::new().exec().unwrap();
     log::info!("FFA version: {}.{}", version.major(), version.minor());
 
+    // Shared EC relay: one physical PL011 channel into the EC firmware,
+    // borrowed by every relay-backed FFA service (currently Thermal;
+    // Battery will migrate in a later task).
+    //
+    // SAFETY: 0x09040000 is the secure PL011 MMIO region exposed to
+    // this SP by the SPMC, declared as an `ec_uart` device-region in
+    // the SP DTS (added/uncommented in a follow-up task). The SP
+    // manifest grants R/W access of >= 0x40 bytes at this base.
+    let pl011 = unsafe { qemu_sp_uart::Pl011Uart::new(0x09040000) };
+    let transport = MctpSerialTransport::new(pl011);
+    let relay = RefCell::new(EcRelay::new(transport));
+
     MessageHandler::new()
-        .append(ec_service_lib::services::Thermal::new())
+        .append(Thermal::new(&relay))
         .append(ec_service_lib::services::FwMgmt::new())
         .append(ec_service_lib::services::Notify::new())
         .append(battery::Battery::new())

--- a/platform/qemu-sp/src/main.rs
+++ b/platform/qemu-sp/src/main.rs
@@ -20,8 +20,8 @@ fn main() {
 #[cfg(target_os = "none")]
 fn main() -> ! {
     use core::cell::RefCell;
-    use ec_service_lib::MessageHandler;
     use ec_service_lib::services::{EcRelay, MctpSerialTransport, Thermal};
+    use ec_service_lib::MessageHandler;
     use odp_ffa::Function;
 
     log::info!("QEMU Secure Partition - build time: {}", env!("BUILD_TIME"));
@@ -29,14 +29,9 @@ fn main() -> ! {
     let version = odp_ffa::Version::new().exec().unwrap();
     log::info!("FFA version: {}.{}", version.major(), version.minor());
 
-    // Shared EC relay: one physical PL011 channel into the EC firmware,
-    // borrowed by every relay-backed FFA service (currently Thermal;
-    // Battery will migrate in a later task).
-    //
-    // SAFETY: 0x09040000 is the secure PL011 MMIO region exposed to
-    // this SP by the SPMC, declared as an `ec_uart` device-region in
-    // the SP DTS (added/uncommented in a follow-up task). The SP
-    // manifest grants R/W access of >= 0x40 bytes at this base.
+    // Shared EC relay over the secure PL011, borrowed by each relay-backed service.
+    // SAFETY: 0x09040000 is the secure PL011 region the SPMC maps to this SP,
+    // declared as the `ec_uart` device-region in the SP DTS.
     let pl011 = unsafe { qemu_sp_uart::Pl011Uart::new(0x09040000) };
     let transport = MctpSerialTransport::new(pl011);
     let relay = RefCell::new(EcRelay::new(transport));

--- a/qemu-sp-uart/src/lib.rs
+++ b/qemu-sp-uart/src/lib.rs
@@ -4,10 +4,11 @@
 
 //! Minimal blocking PL011 MMIO driver for the QEMU SBSA secure partition.
 //!
-//! Polled TX (blocks while `UARTFR.TXFF` is set) and polled RX (busy-wait,
-//! unbounded, via [`Pl011Uart::read_byte_blocking`]). MMIO is fronted by
-//! the [`Mmio`] trait so the bit-twiddling is host-testable with a mock
-//! backend.
+//! Polled TX (blocks while `UARTFR.TXFF` is set) and bounded polled RX
+//! (busy-wait up to [`Pl011Uart::RX_POLL_BUDGET`] iterations, via
+//! [`Pl011Uart::read_byte_blocking`] / [`Pl011Uart::read_byte_bounded`]).
+//! MMIO is fronted by the [`Mmio`] trait so the bit-twiddling is
+//! host-testable with a mock backend.
 //!
 //! # Base address contract
 //!
@@ -91,9 +92,11 @@ pub const FR_TXFF: u32 = 1 << 5; // TX FIFO full
 /// PL011 driver errors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Error {
-    /// Reserved for future bounded-poll variants. Currently unused by the
-    /// shipping methods (`write_bytes`, `read_byte_blocking`); kept for
-    /// API symmetry with the `Result` return types.
+    /// RX poll budget exhausted with `UARTFR.RXFE` still set — the EC
+    /// never produced a byte within the bounded busy-spin window.
+    /// Produced by [`Pl011Uart::read_byte_bounded`] and (via the
+    /// default budget) [`Pl011Uart::read_byte_blocking`]. Surfaces as
+    /// `EcRelayError::TransportReadTimeout` upstream.
     Timeout,
 }
 
@@ -153,11 +156,21 @@ impl<M: Mmio> Pl011Uart<M> {
         Ok(())
     }
 
-    /// Unbounded blocking read of one byte. Busy-spins until
-    /// `UARTFR.RXFE` clears.
-    pub fn read_byte_blocking(&mut self) -> Result<u8, Error> {
-        loop {
-            // SAFETY: see `write_bytes`.
+    /// Default RX-poll budget for `read_byte_blocking`. Sized to be
+    /// effectively infinite for the EC's millisecond-scale responses
+    /// while bounding a stuck link to a finite busy-spin (~seconds
+    /// wall-clock at PL011 polling rate). Surfaced via
+    /// `EcRelayError::TransportReadTimeout` upstream.
+    pub const RX_POLL_BUDGET: u32 = 10_000_000;
+
+    /// Bounded blocking read of one byte. Polls `UARTFR.RXFE` up to
+    /// `budget` times. Returns `Err(Error::Timeout)` if the budget
+    /// is exhausted with RXFE still set.
+    pub fn read_byte_bounded(&mut self, budget: u32) -> Result<u8, Error> {
+        for _ in 0..budget {
+            // SAFETY: `UARTFR` / `UARTDR` are in the device region
+            // passed to `RawMmio::new` (or the mock backend's tracked
+            // offsets in tests).
             let fr = unsafe { self.mmio.read32(UARTFR) };
             if fr & FR_RXFE == 0 {
                 // SAFETY: RXFE clear ⇒ at least one byte in the RX FIFO.
@@ -165,6 +178,13 @@ impl<M: Mmio> Pl011Uart<M> {
             }
             core::hint::spin_loop();
         }
+        Err(Error::Timeout)
+    }
+
+    /// Blocking read of one byte, bounded by [`Self::RX_POLL_BUDGET`].
+    /// Returns `Err(Error::Timeout)` if the EC never responds.
+    pub fn read_byte_blocking(&mut self) -> Result<u8, Error> {
+        self.read_byte_bounded(Self::RX_POLL_BUDGET)
     }
 }
 
@@ -309,5 +329,24 @@ mod tests {
         let mut uart = Pl011Uart::from_mmio(mock);
         assert_eq!(uart.read_byte_blocking().expect("read"), 0xAB);
         assert!(uart.mmio_for_test().fr_read_count() >= 3);
+    }
+
+    #[test]
+    fn read_byte_bounded_returns_timeout_when_rxfe_stays_set() {
+        let mock = MockMmio::new(FR_RXFE, 0xFF); // RXFE always set → never ready
+        let mut uart = Pl011Uart::from_mmio(mock);
+        let err = uart.read_byte_bounded(3).expect_err("should time out");
+        assert_eq!(err, Error::Timeout);
+        assert_eq!(uart.mmio_for_test().fr_read_count(), 3);
+    }
+
+    #[test]
+    fn read_byte_bounded_returns_byte_when_rxfe_clears_before_budget() {
+        let mut mock = MockMmio::new(0, 0xCD); // default 0 = RXFE clear
+        mock.push_fr(FR_RXFE); // first poll: empty
+        mock.push_fr(FR_RXFE); // second poll: empty
+                               // third+ polls: default 0 → ready → reads 0xCD
+        let mut uart = Pl011Uart::from_mmio(mock);
+        assert_eq!(uart.read_byte_bounded(10).expect("read"), 0xCD);
     }
 }

--- a/qemu-sp-uart/src/lib.rs
+++ b/qemu-sp-uart/src/lib.rs
@@ -13,11 +13,11 @@
 //! # Base address contract
 //!
 //! [`Pl011Uart::new`] takes the MMIO `base` as a constructor parameter; the
-//! literal device address (`0x60030000` for the SP-side `ec_uart`) is NOT
+//! literal device address (`0x09040000` for the SP-side `ec_uart`) is NOT
 //! hard-coded inside this crate. The address is declared in the outer
 //! platform repo's SP DTS (`odp-platform-qemu-sbsa` →
 //! `mod/secure-services/platform/linker/qemu-ec-sp.dts`). The platform
-//! binary wires `Pl011Uart::new(0x60030000)` from `qemu-ec-sp::main`.
+//! binary wires `Pl011Uart::new(0x09040000)` from `qemu-ec-sp::main`.
 //!
 //! # Safety contract
 //!

--- a/qemu-sp-uart/src/lib.rs
+++ b/qemu-sp-uart/src/lib.rs
@@ -5,10 +5,9 @@
 //! Minimal blocking PL011 MMIO driver for the QEMU SBSA secure partition.
 //!
 //! Polled TX (blocks while `UARTFR.TXFF` is set) and bounded polled RX
-//! (busy-wait up to [`Pl011Uart::RX_POLL_BUDGET`] iterations, via
-//! [`Pl011Uart::read_byte_blocking`] / [`Pl011Uart::read_byte_bounded`]).
-//! MMIO is fronted by the [`Mmio`] trait so the bit-twiddling is
-//! host-testable with a mock backend.
+//! (via [`Pl011Uart::read_byte_blocking`]). MMIO is fronted by the
+//! [`Mmio`] trait so the bit-twiddling is host-testable with a mock
+//! backend.
 //!
 //! # Base address contract
 //!
@@ -92,11 +91,7 @@ pub const FR_TXFF: u32 = 1 << 5; // TX FIFO full
 /// PL011 driver errors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Error {
-    /// RX poll budget exhausted with `UARTFR.RXFE` still set — the EC
-    /// never produced a byte within the bounded busy-spin window.
-    /// Produced by [`Pl011Uart::read_byte_bounded`] and (via the
-    /// default budget) [`Pl011Uart::read_byte_blocking`]. Surfaces as
-    /// `EcRelayError::TransportReadTimeout` upstream.
+    /// RX poll budget exhausted before a byte arrived.
     Timeout,
 }
 
@@ -156,21 +151,15 @@ impl<M: Mmio> Pl011Uart<M> {
         Ok(())
     }
 
-    /// Default RX-poll budget for `read_byte_blocking`. Sized to be
-    /// effectively infinite for the EC's millisecond-scale responses
-    /// while bounding a stuck link to a finite busy-spin (~seconds
-    /// wall-clock at PL011 polling rate). Surfaced via
-    /// `EcRelayError::TransportReadTimeout` upstream.
+    /// Default RX-poll budget for `read_byte_blocking`: ample for the
+    /// EC's ms-scale responses, finite so a stuck link can't hang.
     pub const RX_POLL_BUDGET: u32 = 10_000_000;
 
-    /// Bounded blocking read of one byte. Polls `UARTFR.RXFE` up to
-    /// `budget` times. Returns `Err(Error::Timeout)` if the budget
-    /// is exhausted with RXFE still set.
+    /// Read one byte, polling `UARTFR.RXFE` up to `budget` times;
+    /// `Err(Error::Timeout)` if exhausted.
     pub fn read_byte_bounded(&mut self, budget: u32) -> Result<u8, Error> {
         for _ in 0..budget {
-            // SAFETY: `UARTFR` / `UARTDR` are in the device region
-            // passed to `RawMmio::new` (or the mock backend's tracked
-            // offsets in tests).
+            // SAFETY: see `write_bytes`.
             let fr = unsafe { self.mmio.read32(UARTFR) };
             if fr & FR_RXFE == 0 {
                 // SAFETY: RXFE clear ⇒ at least one byte in the RX FIFO.
@@ -182,7 +171,6 @@ impl<M: Mmio> Pl011Uart<M> {
     }
 
     /// Blocking read of one byte, bounded by [`Self::RX_POLL_BUDGET`].
-    /// Returns `Err(Error::Timeout)` if the EC never responds.
     pub fn read_byte_blocking(&mut self) -> Result<u8, Error> {
         self.read_byte_bounded(Self::RX_POLL_BUDGET)
     }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -53,10 +53,42 @@ criteria = "safe-to-deploy"
 version = "0.4.44"
 criteria = "safe-to-deploy"
 
+[[exemptions.document-features]]
+version = "0.2.12"
+criteria = "safe-to-run"
+
+[[exemptions.embassy-time]]
+version = "0.5.1"
+criteria = "safe-to-run"
+
+[[exemptions.embassy-time-driver]]
+version = "0.2.2"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-fans]]
+version = "0.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-fans-async]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-hal-async]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
 [[exemptions.embedded-io]]
 version = "0.6.1"
 criteria = "safe-to-deploy"
 notes = "Widely-used embedded-io traits from Embedded WG (Dirbaio). Delta to 0.7.1 covered by ODP import."
+
+[[exemptions.embedded-sensors-hal]]
+version = "0.1.1"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-sensors-hal-async]]
+version = "0.3.0"
+criteria = "safe-to-run"
 
 [[exemptions.futures-core]]
 version = "0.3.32"
@@ -102,6 +134,10 @@ criteria = "safe-to-deploy"
 version = "0.2.186"
 criteria = "safe-to-deploy"
 
+[[exemptions.litrs]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
 [[exemptions.memchr]]
 version = "2.8.0"
 criteria = "safe-to-run"
@@ -135,6 +171,10 @@ notes = "thiserror proc-macro transitive."
 
 [[exemptions.tock-registers]]
 version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.uuid]]
+version = "1.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -177,10 +177,6 @@ criteria = "safe-to-deploy"
 version = "1.17.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.uuid]]
-version = "1.23.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.wasm-bindgen]]
 version = "0.2.122"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Makes the `Thermal` FF-A service a thin **relay shim** over the EC (mirroring `Battery`): `get_temperature` is forwarded to the EC's thermal service over the MCTP-over-PL011 link instead of returning a hardcoded constant. This is the **GetTmp tracer slice** of the SP↔EC thermal relay.

## What's here (7 commits)

**Feature**
- **bound PL011 reads + `TransportReadTimeout`** — `recv_framed_packet`/`read_byte_blocking` could busy-spin forever on a silent link; a read budget surfaces `EcRelayError::TransportReadTimeout` so a dead EC yields an FF-A error, not a hang.
- **`Thermal<R: Relay>` shim + GetTmp** — `Thermal<'r, R: Relay>` holds only `relay: &RefCell<R>` (no local state). `get_temperature` builds the ODP request (service `0x09`, GetTmp, `[instance_id]`), invokes the relay, parses the `u32` LE DeciKelvin. The other five commands return a structured "not yet relayed" error (see scope). Host loopback wire-format test mirrors `battery.rs`.
- **DTS `ec_uart`** — map the secure PL011 `@0x09040000` so the SP can drive the EC transport.

**Refactor / polish**
- **shared `invoke_request` helper** — collapse the per-command build-header→invoke→validate boilerplate shared by Battery + Thermal; dedup test framing into `test_util`.
- **`ThermalCommand` enum** — replace the `THERMAL_CMD_*` `u16` consts with a `num_enum` enum (mirrors `notify.rs`); the FFA dispatch decodes via `try_from` and matches exhaustively.
- comment trim + `cargo fmt`.

**Supply chain**
- **cargo-vet exemptions** — wiring `thermal-service-relay` (embedded-services `5cc395f`) pulls 9 new HAL/timer crates and exact-pins `uuid = "=1.17.0"`, downgrading the workspace from 1.23.1. The 10 are exempted so `vet-dependencies` passes. ⚠️ **The uuid downgrade + these exemptions are intended to be removed once the SP's embedded-services rev is aligned** — the EC and SP currently pin divergent embedded-services revs, though the `thermal-service-relay` wire format is byte-identical across them today.

## Verified
`cargo test -p ec-service-lib` (91 passed) + `-p qemu-sp-uart`, clippy, `cargo fmt`, `cargo vet --locked`, aarch64 cross-build — all green. End-to-end: a two-QEMU SP↔EC harness asserts an EC-origin `thermal_get_temperature` round-trip (DeciKelvin in range); that harness lands as a separate qemu-sbsa PR.

## Scope (GetTmp tracer)
The de-risking GetTmp slice. The remaining five commands (SetThrs/GetThrs/SetScp/GetVar/SetVar) — wire formats already decided — are a fast follow once the round-trip is reviewed. The in-SP mock state is removed (the EC owns it).
