### PR TITLE
refactor(relay): fallible invoke_request parser (drop min_body_len)

### DIFF
--- a/ec-service-lib/src/services/battery.rs
+++ b/ec-service-lib/src/services/battery.rs
@@ -40,7 +40,7 @@ use core::cell::RefCell;
 
 use uuid::{uuid, Uuid};
 
-use crate::services::ec_relay::{EcRelayError, Relay};
+use crate::services::ec_relay::{take_array, EcRelayError, Relay};
 use crate::{Result, Service};
 use odp_ffa::{Error as FfaError, MsgSendDirectReq2, MsgSendDirectResp2};
 
@@ -52,9 +52,6 @@ pub const BATTERY_SERVICE_ID: u8 = 0x08;
 /// `BatteryCmd::GetBst` discriminant from
 /// `embedded-services/battery-service-relay/src/serialization.rs`.
 pub const BATTERY_CMD_GET_BST: u16 = 2;
-
-/// Body of a `GetBst` response, post-OdpHeader. 16 bytes (4 LE u32 dwords).
-pub const GET_BST_RESPONSE_BODY_LEN: usize = 16;
 
 /// Parsed `GetBst` response (mirrors
 /// `battery_service_interface::BstReturn` field-for-field but stays
@@ -112,18 +109,18 @@ impl<'r, R: Relay> Battery<'r, R> {
     pub fn get_bst(&self, battery_id: u8) -> core::result::Result<BstReturnRaw, BatteryError> {
         self.relay
             .borrow_mut()
-            .invoke_request(
-                BATTERY_SERVICE_ID,
-                BATTERY_CMD_GET_BST,
-                &[battery_id],
-                GET_BST_RESPONSE_BODY_LEN,
-                |payload| BstReturnRaw {
-                    battery_state: u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]),
-                    battery_present_rate: u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]),
-                    battery_remaining_capacity: u32::from_le_bytes([payload[8], payload[9], payload[10], payload[11]]),
-                    battery_present_voltage: u32::from_le_bytes([payload[12], payload[13], payload[14], payload[15]]),
-                },
-            )
+            .invoke_request(BATTERY_SERVICE_ID, BATTERY_CMD_GET_BST, &[battery_id], |body| {
+                let (state, body) = take_array(body)?;
+                let (rate, body) = take_array(body)?;
+                let (capacity, body) = take_array(body)?;
+                let (voltage, _) = take_array(body)?;
+                Ok(BstReturnRaw {
+                    battery_state: u32::from_le_bytes(state),
+                    battery_present_rate: u32::from_le_bytes(rate),
+                    battery_remaining_capacity: u32::from_le_bytes(capacity),
+                    battery_present_voltage: u32::from_le_bytes(voltage),
+                })
+            })
             .map_err(BatteryError::Relay)
     }
 }

--- a/ec-service-lib/src/services/ec_relay.rs
+++ b/ec-service-lib/src/services/ec_relay.rs
@@ -87,6 +87,16 @@ pub fn parse_odp_header(bytes: &[u8]) -> Result<(bool, u8, bool, u16), &'static 
     Ok((is_request, service_id, is_error, message_id))
 }
 
+/// Split the first `N` bytes off `body` as an owned array, returning the
+/// remaining bytes for chained reads, or [`EcRelayError::BodyTooShort`].
+/// `N` is inferred from the caller (e.g. `u32::from_le_bytes` fixes it at
+/// 4), so a command's response length stays derived from its parse rather
+/// than a separate constant that can drift.
+pub fn take_array<const N: usize>(body: &[u8]) -> Result<([u8; N], &[u8]), EcRelayError> {
+    let (head, rest) = body.split_first_chunk::<N>().ok_or(EcRelayError::BodyTooShort)?;
+    Ok((*head, rest))
+}
+
 // ===========================================================================
 // MctpMessageTrait shims so `MctpPacketContext::serialize_packet` accepts
 // our raw header + body bytes (no full SerializableMessage impl needed).
@@ -286,28 +296,25 @@ pub trait Relay {
         F: FnOnce(OdpResponse<'_>) -> Result<R, EcRelayError>;
 
     /// Build the request header, invoke, and validate the response
-    /// envelope (same service + message id, at least `min_body_len`
-    /// bytes) before handing the parser a `min_body_len`-byte slice.
+    /// envelope (same service + message id) before handing the body to
+    /// `parse_body`, which validates its own length/shape and returns an
+    /// `EcRelayError` on a mismatch.
     fn invoke_request<R, F>(
         &mut self,
         service_id: u8,
         message_id: u16,
         request_body: &[u8],
-        min_body_len: usize,
         parse_body: F,
     ) -> Result<R, EcRelayError>
     where
-        F: FnOnce(&[u8]) -> R,
+        F: FnOnce(&[u8]) -> Result<R, EcRelayError>,
     {
         let request_header = build_odp_header(true, service_id, message_id);
         self.invoke(request_header, request_body, |response| {
             if response.service_id != service_id || response.message_id != message_id {
                 return Err(EcRelayError::UnexpectedOdpService);
             }
-            if response.body.len() < min_body_len {
-                return Err(EcRelayError::BodyTooShort);
-            }
-            Ok(parse_body(&response.body[..min_body_len]))
+            parse_body(response.body)
         })
     }
 }

--- a/ec-service-lib/src/services/thermal.rs
+++ b/ec-service-lib/src/services/thermal.rs
@@ -8,7 +8,7 @@ use core::cell::RefCell;
 
 use uuid::{uuid, Uuid};
 
-use crate::services::ec_relay::{EcRelayError, Relay};
+use crate::services::ec_relay::{take_array, EcRelayError, Relay};
 use crate::{Result, Service};
 use odp_ffa::{DirectMessagePayload, Error as FfaError, HasRegisterPayload, MsgSendDirectReq2, MsgSendDirectResp2};
 
@@ -25,8 +25,6 @@ pub enum ThermalCommand {
     GetVar = 5,
     SetVar = 6,
 }
-
-pub const GET_TMP_RESPONSE_BODY_LEN: usize = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThermalError {
@@ -70,8 +68,10 @@ impl<'r, R: Relay> Thermal<'r, R> {
                 THERMAL_SERVICE_ID,
                 ThermalCommand::GetTmp.into(),
                 &[instance_id],
-                GET_TMP_RESPONSE_BODY_LEN,
-                |payload| u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]),
+                |body| {
+                    let (temp, _) = take_array(body)?;
+                    Ok(u32::from_le_bytes(temp))
+                },
             )
             .map_err(ThermalError::Relay)
     }
@@ -128,6 +128,8 @@ mod tests {
     use embedded_services::relay::SerializableMessage;
     use thermal_service_relay::{DeciKelvin, ThermalRequest, ThermalResponse};
 
+    const GET_TMP_RESPONSE_BODY_LEN: usize = 4;
+
     #[test]
     fn produces_canonical_get_tmp_request_bytes() {
         // EC GetTmp response: 2982 dK ≈ 25 °C.
@@ -179,5 +181,20 @@ mod tests {
         let svc = Thermal::new(&relay);
         let err = svc.get_temperature(0).expect_err("timeout should propagate");
         assert_eq!(err, ThermalError::Relay(EcRelayError::TransportReadTimeout));
+    }
+
+    #[test]
+    fn get_temperature_rejects_short_response_body() {
+        // EC replies with a valid GetTmp header but a 2-byte payload (< 4).
+        let response_header = ec_relay::build_odp_header(false, THERMAL_SERVICE_ID, ThermalCommand::GetTmp.into());
+        let framed = frame_response_packets(response_header, &[0xAA, 0xBB]);
+        let mut transport = LoopbackTransport::new();
+        transport.prime_rx(framed.iter().copied());
+        let relay = RefCell::new(EcRelay::new(transport));
+        let svc = Thermal::new(&relay);
+        assert_eq!(
+            svc.get_temperature(0x07),
+            Err(ThermalError::Relay(EcRelayError::BodyTooShort))
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #81. Makes `Relay::invoke_request`'s parser fallible and drops the `min_body_len` parameter, so response length/shape validation lives in one place per command instead of being split between the helper and the parser.

## Why
In #81, `invoke_request` did the length check (`body.len() < min_body_len`) and handed the parser a pre-truncated slice, while the parser positionally indexed assuming the length was already correct. The `min_body_len` argument plus the call-site length constant (`GET_BST_RESPONSE_BODY_LEN`) had to be kept in sync with that indexing — drift-prone.

## What
- Parser closure is now `FnOnce(&[u8]) -> Result<R, EcRelayError>`; `min_body_len` is gone. `invoke_request` validates only the envelope (service + message id) and delegates the full body.
- New `take_array::<N>(body) -> Result<([u8; N], &[u8]), EcRelayError>` helper: splits off a fixed-size chunk (or `BodyTooShort`) and returns the rest for chained reads. `N` is inferred from the parse (`u32::from_le_bytes` fixes it at 4), so a command's response length is derived from its parse rather than a separate constant.
- `Battery::get_bst` reads its four `u32`s cursor-style; `Thermal::get_temperature` reads one. Deleted the now-unused `GET_BST_RESPONSE_BODY_LEN`; `GET_TMP_RESPONSE_BODY_LEN` moved into the thermal test (its only remaining user).
- New test `get_temperature_rejects_short_response_body` asserts `BodyTooShort` on a truncated payload.

Behavior-preserving: same errors on the same inputs (envelope mismatch, `BodyTooShort`); trailing bytes still ignored, matching the prior `>= min_body_len` behavior.

## Verified
`cargo test -p ec-service-lib` (92), clippy, `cargo fmt`, `cargo vet --locked`, `cargo doc` (broken-intra-doc-links clean), aarch64 cross-build — all green.
