### PR TITLE
Relay TimeAlarm timer values

### DIFF
--- a/ec-service-lib/src/services/ec_relay.rs
+++ b/ec-service-lib/src/services/ec_relay.rs
@@ -683,22 +683,6 @@ mod tests {
     }
 
     #[test]
-    fn invoke_request_with_response_id_accepts_distinct_success_id() {
-        let header = build_odp_header(false, 0x0B, 5);
-        let body = 300u32.to_le_bytes();
-        let framed = test_util::frame_response_packets(header, &body);
-        let mut transport = test_util::LoopbackTransport::new();
-        transport.prime_rx(framed.iter().copied());
-        let mut relay = EcRelay::new(transport);
-
-        let result = relay.invoke_request_with_response_id(0x0B, 7, 5, &[], |body| {
-            Ok(u32::from_le_bytes(take_exact_array::<4>(body)?))
-        });
-
-        assert_eq!(result, Ok(300));
-    }
-
-    #[test]
     fn invoke_request_with_response_id_rejects_wrong_success_id() {
         let header = build_odp_header(false, 0x0B, 7);
         let framed = test_util::frame_response_packets(header, &300u32.to_le_bytes());

--- a/ec-service-lib/src/services/ec_relay.rs
+++ b/ec-service-lib/src/services/ec_relay.rs
@@ -301,10 +301,8 @@ pub trait Relay {
     where
         F: FnOnce(OdpResponse<'_>) -> Result<R, EcRelayError>;
 
-    /// Build the request header, invoke, and validate the response
-    /// envelope (same service + message id) before handing the body to
-    /// `parse_body`, which validates its own length/shape and returns an
-    /// `EcRelayError` on a mismatch.
+    /// Build a request and validate a success response whose discriminant is
+    /// the same as the request message id.
     fn invoke_request<R, F>(
         &mut self,
         service_id: u8,
@@ -315,7 +313,23 @@ pub trait Relay {
     where
         F: FnOnce(&[u8]) -> Result<R, EcRelayError>,
     {
-        let request_header = build_odp_header(true, service_id, message_id);
+        self.invoke_request_with_response_id(service_id, message_id, message_id, request_body, parse_body)
+    }
+
+    /// Build a request and validate a success response with an explicit
+    /// response discriminant before parsing its body.
+    fn invoke_request_with_response_id<R, F>(
+        &mut self,
+        service_id: u8,
+        request_message_id: u16,
+        expected_response_message_id: u16,
+        request_body: &[u8],
+        parse_body: F,
+    ) -> Result<R, EcRelayError>
+    where
+        F: FnOnce(&[u8]) -> Result<R, EcRelayError>,
+    {
+        let request_header = build_odp_header(true, service_id, request_message_id);
         self.invoke(request_header, request_body, |response| {
             if response.is_request {
                 return Err(EcRelayError::UnexpectedOdpRequest);
@@ -326,7 +340,7 @@ pub trait Relay {
             if response.is_error {
                 return Err(EcRelayError::Remote(response.message_id));
             }
-            if response.message_id != message_id {
+            if response.message_id != expected_response_message_id {
                 return Err(EcRelayError::UnexpectedOdpService);
             }
             parse_body(response.body)
@@ -666,6 +680,48 @@ mod tests {
     #[test]
     fn take_exact_array_rejects_trailing_body() {
         assert_eq!(take_exact_array::<4>(&[1, 2, 3, 4, 5]), Err(EcRelayError::BodyTooLong));
+    }
+
+    #[test]
+    fn invoke_request_with_response_id_accepts_distinct_success_id() {
+        let header = build_odp_header(false, 0x0B, 5);
+        let body = 300u32.to_le_bytes();
+        let framed = test_util::frame_response_packets(header, &body);
+        let mut transport = test_util::LoopbackTransport::new();
+        transport.prime_rx(framed.iter().copied());
+        let mut relay = EcRelay::new(transport);
+
+        let result = relay.invoke_request_with_response_id(0x0B, 7, 5, &[], |body| {
+            Ok(u32::from_le_bytes(take_exact_array::<4>(body)?))
+        });
+
+        assert_eq!(result, Ok(300));
+    }
+
+    #[test]
+    fn invoke_request_with_response_id_rejects_wrong_success_id() {
+        let header = build_odp_header(false, 0x0B, 7);
+        let framed = test_util::frame_response_packets(header, &300u32.to_le_bytes());
+        let mut transport = test_util::LoopbackTransport::new();
+        transport.prime_rx(framed.iter().copied());
+        let mut relay = EcRelay::new(transport);
+
+        let result = relay.invoke_request_with_response_id(0x0B, 7, 5, &[], |_| Ok(()));
+
+        assert_eq!(result, Err(EcRelayError::UnexpectedOdpService));
+    }
+
+    #[test]
+    fn invoke_request_with_response_id_preserves_remote_error() {
+        let header = test_util::build_odp_error_header(0x0B, 1);
+        let framed = test_util::frame_response_packets(header, &[]);
+        let mut transport = test_util::LoopbackTransport::new();
+        transport.prime_rx(framed.iter().copied());
+        let mut relay = EcRelay::new(transport);
+
+        let result = relay.invoke_request_with_response_id(0x0B, 7, 5, &[], |_| Ok(()));
+
+        assert_eq!(result, Err(EcRelayError::Remote(1)));
     }
 
     #[test]

--- a/ec-service-lib/src/services/mod.rs
+++ b/ec-service-lib/src/services/mod.rs
@@ -1,3 +1,8 @@
+use core::mem::size_of;
+
+use odp_ffa::DirectMessagePayload;
+use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
+
 mod battery;
 mod ec_relay;
 mod fw_mgmt;
@@ -17,3 +22,32 @@ pub use time_alarm::TimeAlarm;
 pub use tpm::TpmService;
 pub use tpm_sst::TpmSst;
 pub use tpm_stub::TpmServiceStub;
+
+/// Borrow a typed request from an FFA payload after its command byte.
+fn parse_ffa_request<T>(payload: &DirectMessagePayload) -> Option<&T>
+where
+    T: FromBytes + KnownLayout + Immutable + Unaligned,
+{
+    let start = 1;
+    let end = start + size_of::<T>();
+    T::ref_from_bytes(payload.get(start..end)?).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ffa_request_skips_command_byte() {
+        let payload = DirectMessagePayload::from_iter([0xAA, 1, 2, 3, 4]);
+
+        assert_eq!(parse_ffa_request::<[u8; 4]>(&payload), Some(&[1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn parse_ffa_request_rejects_type_larger_than_payload() {
+        let payload = DirectMessagePayload::from_iter(core::iter::empty());
+
+        assert!(parse_ffa_request::<[u8; 112]>(&payload).is_none());
+    }
+}

--- a/ec-service-lib/src/services/thermal.rs
+++ b/ec-service-lib/src/services/thermal.rs
@@ -8,7 +8,7 @@
 //! byte followed by the canonical EC request body; FFA responses expose
 //! the AML-compatible raw value/status prefix at payload offset zero.
 
-use core::{cell::RefCell, mem::size_of};
+use core::cell::RefCell;
 
 use uuid::{uuid, Uuid};
 
@@ -17,6 +17,7 @@ use zerocopy::{
     FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned,
 };
 
+use super::parse_ffa_request;
 use crate::services::ec_relay::{take_array, take_exact_array, EcRelayError, Relay};
 use crate::{Result, Service};
 use odp_ffa::{DirectMessagePayload, Error as FfaError, HasRegisterPayload, MsgSendDirectReq2, MsgSendDirectResp2};
@@ -128,19 +129,6 @@ fn threshold_payload(timeout: u32, low: u32, high: u32) -> DirectMessagePayload 
             .chain(low.to_le_bytes())
             .chain(high.to_le_bytes()),
     )
-}
-
-/// Borrow a typed request from an FFA payload, skipping the leading
-/// command byte. `ref_from_bytes` requires an exact-length slice, so the
-/// end is fixed at `1 + size_of::<T>()`; a prefix that would run past the
-/// payload end yields `None` instead of panicking.
-fn parse_request<T>(payload: &DirectMessagePayload) -> Option<&T>
-where
-    T: FromBytes + KnownLayout + Immutable + Unaligned,
-{
-    let start = 1;
-    let end = start + size_of::<T>();
-    T::ref_from_bytes(payload.get(start..end)?).ok()
 }
 
 pub struct Thermal<'r, R: Relay> {
@@ -269,7 +257,7 @@ impl<R: Relay> Service for Thermal<'_, R> {
                 Ok(MsgSendDirectResp2::from_req_with_payload(&msg, scalar_payload(value)))
             }
             ThermalCommand::SetThrs => {
-                let status = parse_request::<SetThresholdRequest>(msg.payload())
+                let status = parse_ffa_request::<SetThresholdRequest>(msg.payload())
                     .map(|request| setter_status(self.set_threshold(request)))
                     .unwrap_or(LOCAL_ERROR_SENTINEL);
                 Ok(MsgSendDirectResp2::from_req_with_payload(&msg, scalar_payload(status)))
@@ -282,13 +270,13 @@ impl<R: Relay> Service for Thermal<'_, R> {
                 Ok(MsgSendDirectResp2::from_req_with_payload(&msg, payload))
             }
             ThermalCommand::SetScp => {
-                let status = parse_request::<SetCoolingPolicyRequest>(msg.payload())
+                let status = parse_ffa_request::<SetCoolingPolicyRequest>(msg.payload())
                     .map(|request| setter_status(self.set_scp(request)))
                     .unwrap_or(LOCAL_ERROR_SENTINEL);
                 Ok(MsgSendDirectResp2::from_req_with_payload(&msg, scalar_payload(status)))
             }
             ThermalCommand::GetVar => {
-                let value = match parse_request::<GetVariableRequest>(msg.payload()) {
+                let value = match parse_ffa_request::<GetVariableRequest>(msg.payload()) {
                     Some(request) if request.len.get() == VARIABLE_VALUE_LEN => {
                         self.get_var(request).unwrap_or(LOCAL_ERROR_SENTINEL)
                     }
@@ -297,7 +285,7 @@ impl<R: Relay> Service for Thermal<'_, R> {
                 Ok(MsgSendDirectResp2::from_req_with_payload(&msg, scalar_payload(value)))
             }
             ThermalCommand::SetVar => {
-                let status = match parse_request::<SetVariableRequest>(msg.payload()) {
+                let status = match parse_ffa_request::<SetVariableRequest>(msg.payload()) {
                     Some(request) if request.len.get() == VARIABLE_VALUE_LEN => setter_status(self.set_var(request)),
                     Some(_) => INVALID_PARAMETER_STATUS,
                     None => LOCAL_ERROR_SENTINEL,

--- a/ec-service-lib/src/services/thermal/tests/request_layout.rs
+++ b/ec-service-lib/src/services/thermal/tests/request_layout.rs
@@ -17,19 +17,11 @@ fn set_threshold_request_names_and_preserves_wire_fields() {
     let payload =
         DirectMessagePayload::from_iter(core::iter::once(u16::from(ThermalCommand::SetThrs) as u8).chain(args));
 
-    let request = parse_request::<SetThresholdRequest>(&payload).expect("typed request");
+    let request = parse_ffa_request::<SetThresholdRequest>(&payload).expect("typed request");
 
     assert_eq!(request.instance_id, 7);
     assert_eq!(request.timeout.get(), 0x1122_3344);
     assert_eq!(request.low.get(), 3000);
     assert_eq!(request.high.get(), 3100);
     assert_eq!(request.as_bytes(), &args);
-}
-
-#[test]
-fn parse_request_rejects_type_larger_than_payload() {
-    // A future request type whose command-byte-skipped prefix would run
-    // past the 112-byte payload must yield None, not panic the helper.
-    let payload = DirectMessagePayload::from_iter(core::iter::empty());
-    assert!(parse_request::<[u8; 112]>(&payload).is_none());
 }

--- a/ec-service-lib/src/services/time_alarm.rs
+++ b/ec-service-lib/src/services/time_alarm.rs
@@ -1,8 +1,9 @@
-use core::{cell::RefCell, mem::size_of};
+use core::cell::RefCell;
 
 use uuid::{uuid, Uuid};
 use zerocopy::{byteorder::little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
+use super::parse_ffa_request;
 use crate::services::ec_relay::{take_exact_array, EcRelayError, Relay};
 use crate::{Result, Service};
 use odp_ffa::{DirectMessagePayload, Error as FfaError, HasRegisterPayload, MsgSendDirectReq2, MsgSendDirectResp2};
@@ -56,15 +57,6 @@ fn setter_status(result: core::result::Result<(), TimeAlarmError>) -> u32 {
         Err(TimeAlarmError::Relay(EcRelayError::Remote(code))) => u32::from(code),
         Err(_) => LOCAL_ERROR_SENTINEL,
     }
-}
-
-fn parse_request<T>(payload: &DirectMessagePayload) -> Option<&T>
-where
-    T: FromBytes + KnownLayout + Immutable + Unaligned,
-{
-    let start = 1;
-    let end = start + size_of::<T>();
-    T::ref_from_bytes(payload.get(start..end)?).ok()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -146,13 +138,13 @@ impl<R: Relay> Service for TimeAlarm<'_, R> {
                 ))
             }
             TimeAlarmCommand::SetTimerValue => {
-                let status = parse_request::<SetTimerValueRequest>(msg.payload())
+                let status = parse_ffa_request::<SetTimerValueRequest>(msg.payload())
                     .map(|request| setter_status(self.set_timer_value(request)))
                     .unwrap_or(LOCAL_ERROR_SENTINEL);
                 Ok(MsgSendDirectResp2::from_req_with_payload(&msg, scalar_payload(status)))
             }
             TimeAlarmCommand::GetTimerValue => {
-                let value = parse_request::<GetTimerValueRequest>(msg.payload())
+                let value = parse_ffa_request::<GetTimerValueRequest>(msg.payload())
                     .map(|request| self.get_timer_value(request).unwrap_or(LOCAL_ERROR_SENTINEL))
                     .unwrap_or(LOCAL_ERROR_SENTINEL);
                 Ok(MsgSendDirectResp2::from_req_with_payload(&msg, scalar_payload(value)))
@@ -414,12 +406,6 @@ mod tests {
             ffa_scalar_response(None, &[], TimeAlarmCommand::GetTimerValue, &args,),
             u32::MAX,
         );
-    }
-
-    #[test]
-    fn ffa_timer_request_parser_rejects_oversized_type() {
-        let payload = DirectMessagePayload::from_iter(core::iter::empty());
-        assert!(parse_request::<[u8; 112]>(&payload).is_none());
     }
 
     #[test]

--- a/ec-service-lib/src/services/time_alarm.rs
+++ b/ec-service-lib/src/services/time_alarm.rs
@@ -1,6 +1,7 @@
-use core::cell::RefCell;
+use core::{cell::RefCell, mem::size_of};
 
 use uuid::{uuid, Uuid};
+use zerocopy::{byteorder::little_endian::U32, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::services::ec_relay::{take_exact_array, EcRelayError, Relay};
 use crate::{Result, Service};
@@ -15,6 +16,55 @@ const INVALID_TIMESTAMP: [u8; ACPI_TIMESTAMP_LEN] = [0u8; ACPI_TIMESTAMP_LEN];
 #[repr(u16)]
 pub enum TimeAlarmCommand {
     GetRealTime = 2,
+    SetTimerValue = 6,
+    GetTimerValue = 7,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, num_enum::IntoPrimitive)]
+#[repr(u16)]
+enum TimeAlarmResponseDiscriminant {
+    TimerSeconds = 5,
+    OkNoData = 6,
+}
+
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+struct SetTimerValueRequest {
+    timer_id: U32,
+    seconds: U32,
+}
+
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+struct GetTimerValueRequest {
+    timer_id: U32,
+}
+
+fn parse_empty_response(body: &[u8]) -> core::result::Result<(), EcRelayError> {
+    take_exact_array::<0>(body).map(|_| ())
+}
+
+const LOCAL_ERROR_SENTINEL: u32 = u32::MAX;
+
+fn scalar_payload(value: u32) -> DirectMessagePayload {
+    DirectMessagePayload::from_iter(value.to_le_bytes())
+}
+
+fn setter_status(result: core::result::Result<(), TimeAlarmError>) -> u32 {
+    match result {
+        Ok(()) => 0,
+        Err(TimeAlarmError::Relay(EcRelayError::Remote(code))) => u32::from(code),
+        Err(_) => LOCAL_ERROR_SENTINEL,
+    }
+}
+
+fn parse_request<T>(payload: &DirectMessagePayload) -> Option<&T>
+where
+    T: FromBytes + KnownLayout + Immutable + Unaligned,
+{
+    let start = 1;
+    let end = start + size_of::<T>();
+    T::ref_from_bytes(payload.get(start..end)?).ok()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +98,35 @@ impl<'r, R: Relay> TimeAlarm<'r, R> {
             )
             .map_err(TimeAlarmError::Relay)
     }
+
+    fn set_timer_value(&self, request: &SetTimerValueRequest) -> core::result::Result<(), TimeAlarmError> {
+        self.relay
+            .borrow_mut()
+            .invoke_request_with_response_id(
+                TIME_ALARM_SERVICE_ID,
+                TimeAlarmCommand::SetTimerValue.into(),
+                TimeAlarmResponseDiscriminant::OkNoData.into(),
+                request.as_bytes(),
+                parse_empty_response,
+            )
+            .map_err(TimeAlarmError::Relay)
+    }
+
+    fn get_timer_value(&self, request: &GetTimerValueRequest) -> core::result::Result<u32, TimeAlarmError> {
+        self.relay
+            .borrow_mut()
+            .invoke_request_with_response_id(
+                TIME_ALARM_SERVICE_ID,
+                TimeAlarmCommand::GetTimerValue.into(),
+                TimeAlarmResponseDiscriminant::TimerSeconds.into(),
+                request.as_bytes(),
+                |body| {
+                    let seconds = take_exact_array::<4>(body)?;
+                    Ok(u32::from_le_bytes(seconds))
+                },
+            )
+            .map_err(TimeAlarmError::Relay)
+    }
 }
 
 impl<R: Relay> Service for TimeAlarm<'_, R> {
@@ -66,6 +145,18 @@ impl<R: Relay> Service for TimeAlarm<'_, R> {
                     DirectMessagePayload::from_iter(timestamp),
                 ))
             }
+            TimeAlarmCommand::SetTimerValue => {
+                let status = parse_request::<SetTimerValueRequest>(msg.payload())
+                    .map(|request| setter_status(self.set_timer_value(request)))
+                    .unwrap_or(LOCAL_ERROR_SENTINEL);
+                Ok(MsgSendDirectResp2::from_req_with_payload(&msg, scalar_payload(status)))
+            }
+            TimeAlarmCommand::GetTimerValue => {
+                let value = parse_request::<GetTimerValueRequest>(msg.payload())
+                    .map(|request| self.get_timer_value(request).unwrap_or(LOCAL_ERROR_SENTINEL))
+                    .unwrap_or(LOCAL_ERROR_SENTINEL);
+                Ok(MsgSendDirectResp2::from_req_with_payload(&msg, scalar_payload(value)))
+            }
         }
     }
 }
@@ -79,7 +170,7 @@ mod tests {
     use crate::services::ec_relay::test_util::{frame_response_packets, strip_mctp_framing, LoopbackTransport};
     use crate::services::ec_relay::{self, EcRelay};
     use embedded_services::relay::SerializableMessage;
-    use time_alarm_service_interface::AcpiTimestamp;
+    use time_alarm_service_interface::{AcpiTimerId, AcpiTimestamp, AlarmTimerSeconds};
     use time_alarm_service_relay::{AcpiTimeAlarmRequest, AcpiTimeAlarmResponse};
 
     const RAW_TIMESTAMP: [u8; ACPI_TIMESTAMP_LEN] = [
@@ -105,9 +196,51 @@ mod tests {
         ec_relay::build_odp_header(false, TIME_ALARM_SERVICE_ID, TimeAlarmCommand::GetRealTime.into())
     }
 
-    fn make_ffa_request(command: u8) -> MsgSendDirectReq2 {
-        let payload = DirectMessagePayload::from_iter([command]);
+    fn serialized_response<const N: usize>(response: AcpiTimeAlarmResponse) -> ([u8; 4], [u8; N]) {
+        let response_id = response.discriminant();
+        let mut body = [0u8; N];
+        let written = response.serialize(&mut body).expect("EC-side serialize");
+        assert_eq!(written, N);
+        (
+            ec_relay::build_odp_header(false, TIME_ALARM_SERVICE_ID, response_id),
+            body,
+        )
+    }
+
+    fn relay_with_response(header: [u8; 4], body: &[u8]) -> RefCell<EcRelay<LoopbackTransport>> {
+        let framed = frame_response_packets(header, body);
+        let mut transport = LoopbackTransport::new();
+        transport.prime_rx(framed.iter().copied());
+        RefCell::new(EcRelay::new(transport))
+    }
+
+    fn transmitted_inner(relay: &RefCell<EcRelay<LoopbackTransport>>) -> std::vec::Vec<u8> {
+        strip_mctp_framing(&relay.borrow().transport().tx)
+    }
+
+    fn make_ffa_request(command: u8, args: &[u8]) -> MsgSendDirectReq2 {
+        let payload = DirectMessagePayload::from_iter(core::iter::once(command).chain(args.iter().copied()));
         MsgSendDirectReq2::new(0x0001, 0x8001, TIME_ALARM_UUID, payload)
+    }
+
+    fn ffa_scalar_response(
+        response_header: Option<[u8; 4]>,
+        response_body: &[u8],
+        command: TimeAlarmCommand,
+        args: &[u8],
+    ) -> u32 {
+        let mut transport = LoopbackTransport::new();
+        if let Some(header) = response_header {
+            let framed = frame_response_packets(header, response_body);
+            transport.prime_rx(framed.iter().copied());
+        }
+        let relay = RefCell::new(EcRelay::new(transport));
+        let mut svc = TimeAlarm::new(&relay);
+        let command = u16::from(command) as u8;
+        svc.ffa_msg_send_direct_req2(make_ffa_request(command, args))
+            .expect("known command returns DIRECT_RESP2")
+            .payload()
+            .u32_at(0)
     }
 
     #[test]
@@ -159,6 +292,168 @@ mod tests {
     }
 
     #[test]
+    fn set_timer_value_uses_canonical_wire_contract() {
+        let (header, body) = serialized_response::<0>(AcpiTimeAlarmResponse::OkNoData);
+        let relay = relay_with_response(header, &body);
+        let svc = TimeAlarm::new(&relay);
+        let request = SetTimerValueRequest {
+            timer_id: U32::new(0),
+            seconds: U32::new(300),
+        };
+
+        svc.set_timer_value(&request).expect("synthetic SetTimerValue success");
+
+        let inner = transmitted_inner(&relay);
+        let mut expected = std::vec![0x02, 0x0B, 0x00, 0x06];
+        expected.extend_from_slice(&0u32.to_le_bytes());
+        expected.extend_from_slice(&300u32.to_le_bytes());
+        assert_eq!(inner, expected);
+        assert_eq!(
+            AcpiTimeAlarmRequest::deserialize(6, &inner[4..]).expect("EC decoder accepts SetTimerValue"),
+            AcpiTimeAlarmRequest::SetTimerValue(AcpiTimerId::AcPower, AlarmTimerSeconds(300),),
+        );
+    }
+
+    #[test]
+    fn get_timer_value_uses_canonical_wire_contract() {
+        let (header, body) = serialized_response::<4>(AcpiTimeAlarmResponse::TimerSeconds(AlarmTimerSeconds(297)));
+        let relay = relay_with_response(header, &body);
+        let svc = TimeAlarm::new(&relay);
+        let request = GetTimerValueRequest { timer_id: U32::new(0) };
+
+        assert_eq!(
+            svc.get_timer_value(&request).expect("synthetic GetTimerValue success"),
+            297,
+        );
+
+        let inner = transmitted_inner(&relay);
+        let mut expected = std::vec![0x02, 0x0B, 0x00, 0x07];
+        expected.extend_from_slice(&0u32.to_le_bytes());
+        assert_eq!(inner, expected);
+        assert_eq!(
+            AcpiTimeAlarmRequest::deserialize(7, &inner[4..]).expect("EC decoder accepts GetTimerValue"),
+            AcpiTimeAlarmRequest::GetTimerValue(AcpiTimerId::AcPower),
+        );
+    }
+
+    #[test]
+    fn timer_value_rejects_non_exact_response_bodies() {
+        let set_header = ec_relay::build_odp_header(
+            false,
+            TIME_ALARM_SERVICE_ID,
+            AcpiTimeAlarmResponse::OkNoData.discriminant(),
+        );
+        let set_relay = relay_with_response(set_header, &[0]);
+        let set_svc = TimeAlarm::new(&set_relay);
+        let set_request = SetTimerValueRequest {
+            timer_id: U32::new(0),
+            seconds: U32::new(300),
+        };
+        assert_eq!(
+            set_svc.set_timer_value(&set_request),
+            Err(TimeAlarmError::Relay(EcRelayError::BodyTooLong)),
+        );
+
+        let get_header = ec_relay::build_odp_header(
+            false,
+            TIME_ALARM_SERVICE_ID,
+            AcpiTimeAlarmResponse::TimerSeconds(AlarmTimerSeconds(0)).discriminant(),
+        );
+        let get_request = GetTimerValueRequest { timer_id: U32::new(0) };
+
+        let short_relay = relay_with_response(get_header, &[0; 3]);
+        assert_eq!(
+            TimeAlarm::new(&short_relay).get_timer_value(&get_request),
+            Err(TimeAlarmError::Relay(EcRelayError::BodyTooShort)),
+        );
+
+        let trailing_relay = relay_with_response(get_header, &[0; 5]);
+        assert_eq!(
+            TimeAlarm::new(&trailing_relay).get_timer_value(&get_request),
+            Err(TimeAlarmError::Relay(EcRelayError::BodyTooLong)),
+        );
+    }
+
+    #[test]
+    fn ffa_set_timer_value_maps_success_remote_and_local_errors() {
+        let mut args = [0u8; 8];
+        args[..4].copy_from_slice(&0u32.to_le_bytes());
+        args[4..].copy_from_slice(&300u32.to_le_bytes());
+
+        let success_header = ec_relay::build_odp_header(
+            false,
+            TIME_ALARM_SERVICE_ID,
+            AcpiTimeAlarmResponse::OkNoData.discriminant(),
+        );
+        assert_eq!(
+            ffa_scalar_response(Some(success_header), &[], TimeAlarmCommand::SetTimerValue, &args,),
+            0,
+        );
+
+        let remote_header = ec_relay::test_util::build_odp_error_header(TIME_ALARM_SERVICE_ID, 1);
+        assert_eq!(
+            ffa_scalar_response(Some(remote_header), &[], TimeAlarmCommand::SetTimerValue, &args,),
+            1,
+        );
+
+        assert_eq!(
+            ffa_scalar_response(None, &[], TimeAlarmCommand::SetTimerValue, &args,),
+            u32::MAX,
+        );
+    }
+
+    #[test]
+    fn ffa_get_timer_value_maps_success_and_failures() {
+        let args = 0u32.to_le_bytes();
+        let response = AcpiTimeAlarmResponse::TimerSeconds(AlarmTimerSeconds(297));
+        let (success_header, success_body) = serialized_response::<4>(response);
+        assert_eq!(
+            ffa_scalar_response(
+                Some(success_header),
+                &success_body,
+                TimeAlarmCommand::GetTimerValue,
+                &args,
+            ),
+            297,
+        );
+
+        let remote_header = ec_relay::test_util::build_odp_error_header(TIME_ALARM_SERVICE_ID, 1);
+        assert_eq!(
+            ffa_scalar_response(Some(remote_header), &[], TimeAlarmCommand::GetTimerValue, &args,),
+            u32::MAX,
+        );
+
+        assert_eq!(
+            ffa_scalar_response(None, &[], TimeAlarmCommand::GetTimerValue, &args,),
+            u32::MAX,
+        );
+    }
+
+    #[test]
+    fn ffa_timer_request_layouts_match_arguments() {
+        let mut set_args = [0u8; 8];
+        set_args[..4].copy_from_slice(&1u32.to_le_bytes());
+        set_args[4..].copy_from_slice(&300u32.to_le_bytes());
+        let set_payload = make_ffa_request(u16::from(TimeAlarmCommand::SetTimerValue) as u8, &set_args);
+        let set_request = parse_request::<SetTimerValueRequest>(set_payload.payload()).expect("typed set request");
+        assert_eq!(set_request.timer_id.get(), 1);
+        assert_eq!(set_request.seconds.get(), 300);
+        assert_eq!(set_request.as_bytes(), &set_args);
+
+        let get_args = 0u32.to_le_bytes();
+        let get_payload = make_ffa_request(u16::from(TimeAlarmCommand::GetTimerValue) as u8, &get_args);
+        let get_request = parse_request::<GetTimerValueRequest>(get_payload.payload()).expect("typed get request");
+        assert_eq!(get_request.timer_id.get(), 0);
+        assert_eq!(get_request.as_bytes(), &get_args);
+    }
+
+    #[test]
+    fn ffa_timer_request_parser_rejects_oversized_type() {
+        let payload = DirectMessagePayload::from_iter(core::iter::empty());
+        assert!(parse_request::<[u8; 112]>(&payload).is_none());
+    }
+
+    #[test]
     fn ffa_success_returns_timestamp_at_payload_offset_zero() {
         let body = serialized_timestamp();
         let framed = frame_response_packets(response_header(), &body);
@@ -168,7 +463,7 @@ mod tests {
         let mut svc = TimeAlarm::new(&relay);
 
         let response = svc
-            .ffa_msg_send_direct_req2(make_ffa_request(2))
+            .ffa_msg_send_direct_req2(make_ffa_request(2, &[]))
             .expect("known command returns DIRECT_RESP2");
         for (offset, expected) in body.into_iter().enumerate() {
             assert_eq!(response.payload().u8_at(offset), expected);
@@ -185,7 +480,7 @@ mod tests {
         let mut svc = TimeAlarm::new(&relay);
 
         let response = svc
-            .ffa_msg_send_direct_req2(make_ffa_request(2))
+            .ffa_msg_send_direct_req2(make_ffa_request(2, &[]))
             .expect("known command returns invalid timestamp");
         for offset in 0..ACPI_TIMESTAMP_LEN {
             assert_eq!(response.payload().u8_at(offset), 0);
@@ -196,6 +491,6 @@ mod tests {
     fn rejects_unknown_ffa_command() {
         let relay = RefCell::new(EcRelay::new(LoopbackTransport::new()));
         let mut svc = TimeAlarm::new(&relay);
-        assert!(svc.ffa_msg_send_direct_req2(make_ffa_request(0xFF)).is_err());
+        assert!(svc.ffa_msg_send_direct_req2(make_ffa_request(0xFF, &[])).is_err());
     }
 }

--- a/ec-service-lib/src/services/time_alarm.rs
+++ b/ec-service-lib/src/services/time_alarm.rs
@@ -295,13 +295,18 @@ mod tests {
     fn set_timer_value_uses_canonical_wire_contract() {
         let (header, body) = serialized_response::<0>(AcpiTimeAlarmResponse::OkNoData);
         let relay = relay_with_response(header, &body);
-        let svc = TimeAlarm::new(&relay);
-        let request = SetTimerValueRequest {
-            timer_id: U32::new(0),
-            seconds: U32::new(300),
-        };
+        let mut svc = TimeAlarm::new(&relay);
+        let mut args = [0u8; 8];
+        args[..4].copy_from_slice(&0u32.to_le_bytes());
+        args[4..].copy_from_slice(&300u32.to_le_bytes());
 
-        svc.set_timer_value(&request).expect("synthetic SetTimerValue success");
+        let response = svc
+            .ffa_msg_send_direct_req2(make_ffa_request(
+                u16::from(TimeAlarmCommand::SetTimerValue) as u8,
+                &args,
+            ))
+            .expect("known command returns DIRECT_RESP2");
+        assert_eq!(response.payload().u32_at(0), 0);
 
         let inner = transmitted_inner(&relay);
         let mut expected = std::vec![0x02, 0x0B, 0x00, 0x06];
@@ -318,13 +323,16 @@ mod tests {
     fn get_timer_value_uses_canonical_wire_contract() {
         let (header, body) = serialized_response::<4>(AcpiTimeAlarmResponse::TimerSeconds(AlarmTimerSeconds(297)));
         let relay = relay_with_response(header, &body);
-        let svc = TimeAlarm::new(&relay);
-        let request = GetTimerValueRequest { timer_id: U32::new(0) };
+        let mut svc = TimeAlarm::new(&relay);
+        let args = 0u32.to_le_bytes();
 
-        assert_eq!(
-            svc.get_timer_value(&request).expect("synthetic GetTimerValue success"),
-            297,
-        );
+        let response = svc
+            .ffa_msg_send_direct_req2(make_ffa_request(
+                u16::from(TimeAlarmCommand::GetTimerValue) as u8,
+                &args,
+            ))
+            .expect("known command returns DIRECT_RESP2");
+        assert_eq!(response.payload().u32_at(0), 297);
 
         let inner = transmitted_inner(&relay);
         let mut expected = std::vec![0x02, 0x0B, 0x00, 0x07];
@@ -375,20 +383,10 @@ mod tests {
     }
 
     #[test]
-    fn ffa_set_timer_value_maps_success_remote_and_local_errors() {
+    fn ffa_set_timer_value_maps_remote_and_local_errors() {
         let mut args = [0u8; 8];
         args[..4].copy_from_slice(&0u32.to_le_bytes());
         args[4..].copy_from_slice(&300u32.to_le_bytes());
-
-        let success_header = ec_relay::build_odp_header(
-            false,
-            TIME_ALARM_SERVICE_ID,
-            AcpiTimeAlarmResponse::OkNoData.discriminant(),
-        );
-        assert_eq!(
-            ffa_scalar_response(Some(success_header), &[], TimeAlarmCommand::SetTimerValue, &args,),
-            0,
-        );
 
         let remote_header = ec_relay::test_util::build_odp_error_header(TIME_ALARM_SERVICE_ID, 1);
         assert_eq!(
@@ -403,19 +401,8 @@ mod tests {
     }
 
     #[test]
-    fn ffa_get_timer_value_maps_success_and_failures() {
+    fn ffa_get_timer_value_maps_remote_and_local_errors() {
         let args = 0u32.to_le_bytes();
-        let response = AcpiTimeAlarmResponse::TimerSeconds(AlarmTimerSeconds(297));
-        let (success_header, success_body) = serialized_response::<4>(response);
-        assert_eq!(
-            ffa_scalar_response(
-                Some(success_header),
-                &success_body,
-                TimeAlarmCommand::GetTimerValue,
-                &args,
-            ),
-            297,
-        );
 
         let remote_header = ec_relay::test_util::build_odp_error_header(TIME_ALARM_SERVICE_ID, 1);
         assert_eq!(
@@ -427,24 +414,6 @@ mod tests {
             ffa_scalar_response(None, &[], TimeAlarmCommand::GetTimerValue, &args,),
             u32::MAX,
         );
-    }
-
-    #[test]
-    fn ffa_timer_request_layouts_match_arguments() {
-        let mut set_args = [0u8; 8];
-        set_args[..4].copy_from_slice(&1u32.to_le_bytes());
-        set_args[4..].copy_from_slice(&300u32.to_le_bytes());
-        let set_payload = make_ffa_request(u16::from(TimeAlarmCommand::SetTimerValue) as u8, &set_args);
-        let set_request = parse_request::<SetTimerValueRequest>(set_payload.payload()).expect("typed set request");
-        assert_eq!(set_request.timer_id.get(), 1);
-        assert_eq!(set_request.seconds.get(), 300);
-        assert_eq!(set_request.as_bytes(), &set_args);
-
-        let get_args = 0u32.to_le_bytes();
-        let get_payload = make_ffa_request(u16::from(TimeAlarmCommand::GetTimerValue) as u8, &get_args);
-        let get_request = parse_request::<GetTimerValueRequest>(get_payload.payload()).expect("typed get request");
-        assert_eq!(get_request.timer_id.get(), 0);
-        assert_eq!(get_request.as_bytes(), &get_args);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- relay TimeAlarm `SetTimerValue` and `GetTimerValue` through the EC
- validate canonical request/response discriminants (`6 -> 6`, `7 -> 5`)
- preserve the existing AML raw status/value ABI with focused protocol tests

## Architecture

`Relay::invoke_request_with_response_id` keeps remote-error handling ahead of success-discriminant validation while preserving the existing equal-ID helper. TimeAlarm uses typed zerocopy request layouts and exact empty/four-byte response parsing.

## Code-judo review

An independent simplification pass consolidated duplicate positive assurance into FFA-to-wire contract tests: **47 net test LOC removed**, no production churn, with malformed-body, wrong-ID, remote-error, oversized-parser, and GetRealTime boundaries retained.

## Validation

- `cargo test --locked -p ec-service-lib` — 116 passed
- `cargo clippy --locked -p ec-service-lib --tests -- -D warnings`
- `cargo check --locked -p ec-service-lib --target aarch64-unknown-none`
- `cargo check --locked -p ec-service-lib --target aarch64-unknown-none-softfloat`
- repository pre-commit/feature/build gates passed
- dependent TimeAlarm, Thermal, Battery, and aggregate ArmVirt E2Es passed

## Downstream

Dependent ArmVirt PR will track:
https://github.com/OpenDevicePartnership/odp-platform-qemu-arm-virt/issues/127