### PR TITLE
Ignore bare-metal advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     #{ id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; transitive dep via embedded-services. No safe upgrade available, awaiting upstream migration to pastey." },
+    { id = "RUSTSEC-2026-0110", reason = "bare-metal is unmaintained; transitive host-test dependency via embedded-services and cortex-m. No safe upgrade is available." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
## Summary
- document a narrow cargo-deny exception for RUSTSEC-2026-0110
- restore the advisory check after the RustSec database update broke current main

## Root cause
`bare-metal 0.2.5` was newly marked unmaintained after the last successful main run. It is an existing transitive host-test dependency through embedded-services/cortex-m, and the advisory has no safe upgrade.

## Validation
- `cargo deny check advisories`
- full repository pre-commit checks
- fork CI green: https://github.com/dymk/odp-secure-services/pull/14