### PR TITLE
Add secure-world UCSI test stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,20 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,12 +295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
-
-[[package]]
 name = "embassy-futures"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,9 +473,8 @@ dependencies = [
 [[package]]
 name = "embedded-usb-pd"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?rev=bc8c582395ee4861be95110d4097a0b39de01717#bc8c582395ee4861be95110d4097a0b39de01717"
 dependencies = [
- "aquamarine",
  "bincode",
  "bitfield 0.19.5",
  "embedded-hal-async",
@@ -688,25 +667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,15 +674,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -860,27 +811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aquamarine"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
+dependencies = [
+ "include_dir",
+ "itertools",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "unty",
+]
+
+[[package]]
 name = "bit-register"
 version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/odp-utilities?tag=v0.1.0#583015c08ad9855f310bdb25d5cf9abff77b5e08"
@@ -126,6 +149,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f798d2d157e547aa99aab0967df39edd0b70307312b6f8bd2848e6abe40896e0"
 
 [[package]]
+name = "bitfield"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45721c9db4c7a20899d05efb7ad9235f50b256e980db30ffb229abf732934c3"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cb6f3d4773a2107b94cbeccaa5b5f0b35a88389b5d522d13d659f64317b22d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "bitfield-struct"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,7 +176,7 @@ checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -253,6 +296,7 @@ dependencies = [
  "battery-service-relay",
  "embedded-io",
  "embedded-services",
+ "embedded-usb-pd",
  "log",
  "mctp-rs",
  "num_enum",
@@ -263,6 +307,12 @@ dependencies = [
  "uuid",
  "zerocopy",
 ]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embassy-futures"
@@ -441,6 +491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-usb-pd"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-usb-pd?tag=v0.1.0#0061a1e94a25c8db33ac1e8a0bb5a6b638fe2cd7"
+dependencies = [
+ "aquamarine",
+ "bincode",
+ "bitfield 0.19.5",
+ "embedded-hal-async",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,7 +560,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -627,6 +688,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +714,15 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -727,7 +816,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -771,6 +860,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -875,7 +985,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -951,7 +1061,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -996,7 +1106,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1004,6 +1114,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1048,7 +1169,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1116,6 +1237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "uuid"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1304,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1211,7 +1338,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1222,7 +1349,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1275,5 +1402,5 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ thermal-service-relay = { git = "https://github.com/OpenDevicePartnership/embedd
 time-alarm-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "0cadc205b55fe829df3c8cb3accb5cc565422ccc", default-features = false }
 time-alarm-service-interface = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "0cadc205b55fe829df3c8cb3accb5cc565422ccc", default-features = false }
 # Host-test-only wire-format oracle for the UCSI stub (see ec-service-lib/src/services/ucsi.rs).
-embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0", default-features = false }
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", rev = "bc8c582395ee4861be95110d4097a0b39de01717", default-features = false, features = ["ucsi-v1_2"] }
 embedded-io = { version = "0.7", default-features = false }
 log = { version = "0.4", default-features = false }
 mockall = "0.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ battery-service-interface = { git = "https://github.com/OpenDevicePartnership/em
 thermal-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "0cadc205b55fe829df3c8cb3accb5cc565422ccc", default-features = false }
 time-alarm-service-relay = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "0cadc205b55fe829df3c8cb3accb5cc565422ccc", default-features = false }
 time-alarm-service-interface = { git = "https://github.com/OpenDevicePartnership/embedded-services.git", rev = "0cadc205b55fe829df3c8cb3accb5cc565422ccc", default-features = false }
+# Host-test-only wire-format oracle for the UCSI stub (see ec-service-lib/src/services/ucsi.rs).
+embedded-usb-pd = { git = "https://github.com/OpenDevicePartnership/embedded-usb-pd", tag = "v0.1.0", default-features = false }
 embedded-io = { version = "0.7", default-features = false }
 log = { version = "0.4", default-features = false }
 mockall = "0.13.1"

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     #{ id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; transitive dep via embedded-services. No safe upgrade available, awaiting upstream migration to pastey." },
+    { id = "RUSTSEC-2025-0141", reason = "bincode is an unmaintained transitive dependency of the host-test-only embedded-usb-pd wire-format oracle. It is not linked into secure-partition builds, and no safe upgrade is available." },
     { id = "RUSTSEC-2026-0110", reason = "bare-metal is unmaintained; transitive host-test dependency via embedded-services and cortex-m. No safe upgrade is available." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.

--- a/ec-service-lib/Cargo.toml
+++ b/ec-service-lib/Cargo.toml
@@ -38,6 +38,9 @@ battery-service-interface.workspace = true
 thermal-service-relay.workspace = true
 time-alarm-service-relay.workspace = true
 time-alarm-service-interface.workspace = true
+# Independent UCSI wire-format oracle — used only by host `#[cfg(test)]` gate
+# tests in services/ucsi.rs. Never a runtime dep (the SP hand-encodes bytes).
+embedded-usb-pd.workspace = true
 
 [features]
 default = []

--- a/ec-service-lib/src/services/mod.rs
+++ b/ec-service-lib/src/services/mod.rs
@@ -12,6 +12,7 @@ mod time_alarm;
 mod tpm;
 mod tpm_sst;
 mod tpm_stub;
+mod ucsi;
 
 pub use battery::Battery;
 pub use ec_relay::{EcRelay, MctpSerialTransport, OdpTransport, Relay};
@@ -22,6 +23,7 @@ pub use time_alarm::TimeAlarm;
 pub use tpm::TpmService;
 pub use tpm_sst::TpmSst;
 pub use tpm_stub::TpmServiceStub;
+pub use ucsi::Ucsi;
 
 /// Borrow a typed request from an FFA payload after its command byte.
 fn parse_ffa_request<T>(payload: &DirectMessagePayload) -> Option<&T>

--- a/ec-service-lib/src/services/ucsi.rs
+++ b/ec-service-lib/src/services/ucsi.rs
@@ -113,11 +113,11 @@ extern crate std;
 mod tests {
     use super::*;
 
-    use embedded_usb_pd::ucsi::cci::LocalCci;
-    use embedded_usb_pd::ucsi::lpm::get_connector_capability as gcc;
-    use embedded_usb_pd::ucsi::lpm::get_connector_status as gcs;
-    use embedded_usb_pd::ucsi::ppm::get_capability as gcap;
-    use embedded_usb_pd::ucsi::{lpm, ppm, ResponseData};
+    use embedded_usb_pd::ucsi::v1_2::cci::LocalCci;
+    use embedded_usb_pd::ucsi::v1_2::lpm::get_connector_capability as gcc;
+    use embedded_usb_pd::ucsi::v1_2::lpm::get_connector_status as gcs;
+    use embedded_usb_pd::ucsi::v1_2::ppm::get_capability as gcap;
+    use embedded_usb_pd::ucsi::v1_2::{lpm, ppm, ResponseData};
     use embedded_usb_pd::PowerRole;
 
     const DOORBELL: u8 = 0x00;

--- a/ec-service-lib/src/services/ucsi.rs
+++ b/ec-service-lib/src/services/ucsi.rs
@@ -1,0 +1,275 @@
+//! `Ucsi` — secure-world UCSI Platform Policy Manager (PPM) test stub.
+//!
+//! Returns deterministic fake data so the OS side can exercise the full
+//! UCSI-over-FF-A-through-ACPI path against QEMU. The request carries a
+//! doorbell tag byte followed by the 48-byte UCSI mailbox inline in the
+//! FF-A register payload; the response returns the updated mailbox at
+//! payload offset 0.
+//!
+//! # Mailbox layout (48 bytes, UCSI 1.2)
+//! `VERSION@0 (u16)`, `RESERVED@2`, `CCI@4 (u32)`, `CONTROL@8 (8 bytes,
+//! opcode at byte 0, connector number at byte 2)`, `MESSAGE IN@16 (16
+//! bytes)`, `MESSAGE OUT@32 (16 bytes)`.
+//!
+//! # Manual encoding
+//! `embedded-usb-pd` does not compile for `aarch64-unknown-none[-softfloat]`,
+//! so the fake `MESSAGE IN` payloads are held as `const` byte arrays and the
+//! CCI is hand-written. The host-only wire-format gate test round-trips each
+//! fixture through the upstream `embedded-usb-pd` encoder so the bytes can
+//! never silently drift from valid UCSI wire data.
+
+use uuid::{uuid, Uuid};
+
+use crate::{Result, Service};
+use odp_ffa::{DirectMessagePayload, Error as FfaError, HasRegisterPayload, MsgSendDirectReq2, MsgSendDirectResp2};
+
+pub const UCSI_UUID: Uuid = uuid!("65467f50-827f-4e4f-8770-dbf4c3f77f45");
+
+const MAILBOX_LEN: usize = 48;
+/// The 48-byte mailbox starts after the doorbell tag byte in the FF-A payload.
+const MAILBOX_PAYLOAD_START: usize = 1;
+const VERSION_OFFSET: usize = 0;
+const CCI_OFFSET: usize = 4;
+const CONTROL_OFFSET: usize = 8;
+const MESSAGE_IN_OFFSET: usize = 16;
+
+/// UCSI 1.2.
+const VERSION: u16 = 0x0120;
+/// The doorbell tag the OS writes at FF-A payload byte 0.
+const DOORBELL: u8 = 0x00;
+/// Only a single connector (connector #1) is modeled.
+const CONNECTOR_ONE: u8 = 1;
+
+const OP_GET_CAPABILITY: u8 = 0x06;
+const OP_GET_CONNECTOR_CAPABILITY: u8 = 0x07;
+const OP_GET_CONNECTOR_STATUS: u8 = 0x12;
+
+// CCI = cmd_complete (bit31) | data_len (bits 15..8). See embedded-usb-pd cci.rs.
+const CCI_CAPABILITY: u32 = 0x8000_1000;
+const CCI_CONNECTOR_CAPABILITY: u32 = 0x8000_0200;
+const CCI_CONNECTOR_STATUS: u32 = 0x8000_0B00;
+/// not_supported (bit25), no data.
+const CCI_NOT_SUPPORTED: u32 = 0x0200_0000;
+
+// Deterministic single-connector USB-PD sink fixtures. Validated byte-for-byte
+// against the embedded-usb-pd encoder in `fixtures_match_embedded_usb_pd_encoder`.
+const CAPABILITY_MESSAGE_IN: [u8; 16] = [
+    0x46, 0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x01, 0x00, 0x03, 0x00, 0x02,
+];
+const CONNECTOR_CAPABILITY_MESSAGE_IN: [u8; 2] = [0x64, 0x03];
+const CONNECTOR_STATUS_MESSAGE_IN: [u8; 11] = [0x00, 0x00, 0x29, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+#[derive(Default)]
+pub struct Ucsi;
+
+impl Ucsi {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Service for Ucsi {
+    const UUID: Uuid = UCSI_UUID;
+    const NAME: &'static str = "Ucsi";
+
+    fn ffa_msg_send_direct_req2(&mut self, msg: MsgSendDirectReq2) -> Result<MsgSendDirectResp2> {
+        let payload = msg.payload();
+        if payload.u8_at(0) != DOORBELL {
+            return Err(FfaError::Other("UCSI: unexpected doorbell tag"));
+        }
+
+        let mut mailbox = [0u8; MAILBOX_LEN];
+        mailbox.copy_from_slice(payload.slice(MAILBOX_PAYLOAD_START..MAILBOX_PAYLOAD_START + MAILBOX_LEN));
+
+        let opcode = mailbox[CONTROL_OFFSET];
+        let connector = mailbox[CONTROL_OFFSET + 2];
+        let (cci, message_in): (u32, &[u8]) = match opcode {
+            OP_GET_CAPABILITY => (CCI_CAPABILITY, &CAPABILITY_MESSAGE_IN),
+            OP_GET_CONNECTOR_CAPABILITY if connector == CONNECTOR_ONE => {
+                (CCI_CONNECTOR_CAPABILITY, &CONNECTOR_CAPABILITY_MESSAGE_IN)
+            }
+            OP_GET_CONNECTOR_STATUS if connector == CONNECTOR_ONE => {
+                (CCI_CONNECTOR_STATUS, &CONNECTOR_STATUS_MESSAGE_IN)
+            }
+            _ => (CCI_NOT_SUPPORTED, &[]),
+        };
+
+        mailbox[VERSION_OFFSET..VERSION_OFFSET + 2].copy_from_slice(&VERSION.to_le_bytes());
+        mailbox[CCI_OFFSET..CCI_OFFSET + 4].copy_from_slice(&cci.to_le_bytes());
+        mailbox[MESSAGE_IN_OFFSET..].fill(0);
+        mailbox[MESSAGE_IN_OFFSET..MESSAGE_IN_OFFSET + message_in.len()].copy_from_slice(message_in);
+
+        Ok(MsgSendDirectResp2::from_req_with_payload(
+            &msg,
+            DirectMessagePayload::from_iter(mailbox),
+        ))
+    }
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use embedded_usb_pd::ucsi::cci::LocalCci;
+    use embedded_usb_pd::ucsi::lpm::get_connector_capability as gcc;
+    use embedded_usb_pd::ucsi::lpm::get_connector_status as gcs;
+    use embedded_usb_pd::ucsi::ppm::get_capability as gcap;
+    use embedded_usb_pd::ucsi::{lpm, ppm, ResponseData};
+    use embedded_usb_pd::PowerRole;
+
+    const DOORBELL: u8 = 0x00;
+
+    /// Build an FF-A request carrying the doorbell tag + a 48-byte mailbox
+    /// with `opcode` at CONTROL offset 0 and `connector` at CONTROL offset 2.
+    fn request(opcode: u8, connector: u8) -> MsgSendDirectReq2 {
+        let mut mailbox = [0u8; MAILBOX_LEN];
+        mailbox[CONTROL_OFFSET] = opcode;
+        mailbox[CONTROL_OFFSET + 2] = connector;
+        let payload = DirectMessagePayload::from_iter(core::iter::once(DOORBELL).chain(mailbox));
+        MsgSendDirectReq2::new(0x0001, 0x8001, UCSI_UUID, payload)
+    }
+
+    fn respond(opcode: u8, connector: u8) -> DirectMessagePayload {
+        Ucsi::new()
+            .ffa_msg_send_direct_req2(request(opcode, connector))
+            .expect("UCSI always answers with a mailbox")
+            .payload()
+            .clone()
+    }
+
+    fn message_in(mailbox: &DirectMessagePayload, len: usize) -> std::vec::Vec<u8> {
+        mailbox.slice(MESSAGE_IN_OFFSET..MESSAGE_IN_OFFSET + len).to_vec()
+    }
+
+    #[test]
+    fn get_capability_returns_fixture_and_cci() {
+        let m = respond(0x06, 0);
+        assert_eq!(m.u16_at(VERSION_OFFSET), VERSION);
+        assert_eq!(m.u32_at(CCI_OFFSET), CCI_CAPABILITY);
+        assert_eq!(message_in(&m, CAPABILITY_MESSAGE_IN.len()), CAPABILITY_MESSAGE_IN);
+        // CONTROL is echoed back untouched.
+        assert_eq!(m.u8_at(CONTROL_OFFSET), 0x06);
+    }
+
+    #[test]
+    fn get_connector_capability_returns_fixture_and_cci() {
+        let m = respond(0x07, 1);
+        assert_eq!(m.u32_at(CCI_OFFSET), CCI_CONNECTOR_CAPABILITY);
+        assert_eq!(
+            message_in(&m, CONNECTOR_CAPABILITY_MESSAGE_IN.len()),
+            CONNECTOR_CAPABILITY_MESSAGE_IN
+        );
+    }
+
+    #[test]
+    fn get_connector_status_returns_fixture_and_cci() {
+        let m = respond(0x12, 1);
+        assert_eq!(m.u32_at(CCI_OFFSET), CCI_CONNECTOR_STATUS);
+        assert_eq!(
+            message_in(&m, CONNECTOR_STATUS_MESSAGE_IN.len()),
+            CONNECTOR_STATUS_MESSAGE_IN
+        );
+    }
+
+    #[test]
+    fn unknown_opcode_reports_not_supported_with_zeroed_message_in() {
+        let m = respond(0x13, 0);
+        assert_eq!(m.u16_at(VERSION_OFFSET), VERSION);
+        assert_eq!(m.u32_at(CCI_OFFSET), CCI_NOT_SUPPORTED);
+        assert_eq!(
+            m.slice(MESSAGE_IN_OFFSET..MAILBOX_LEN),
+            [0u8; MAILBOX_LEN - MESSAGE_IN_OFFSET]
+        );
+    }
+
+    #[test]
+    fn invalid_connector_reports_not_supported_with_zeroed_message_in() {
+        for opcode in [0x07u8, 0x12u8] {
+            let m = respond(opcode, 2);
+            assert_eq!(m.u32_at(CCI_OFFSET), CCI_NOT_SUPPORTED);
+            assert_eq!(
+                m.slice(MESSAGE_IN_OFFSET..MAILBOX_LEN),
+                [0u8; MAILBOX_LEN - MESSAGE_IN_OFFSET]
+            );
+        }
+    }
+
+    /// Wire-format gate: the hand-encoded fixture consts and CCI values must
+    /// equal what the upstream `embedded-usb-pd` encoder produces, proving the
+    /// SP emits valid UCSI 1.2 wire bytes (and can never silently drift).
+    #[test]
+    fn fixtures_match_embedded_usb_pd_encoder() {
+        let mut cap = gcap::ResponseData::default();
+        cap.attributes
+            .set_battery_charging(true)
+            .set_usb_power_delivery(true)
+            .set_usb_type_c_current(true)
+            .set_power_source(*gcap::PowerSource::default().set_use_vbus(true));
+        cap.num_connectors = 1;
+        cap.bcd_battery_charging_spec = 0x0120;
+        cap.bcd_usb_pd_spec = 0x0300;
+        cap.bcd_type_c_spec = 0x0200;
+        let mut cap_bytes = [0u8; 16];
+        ResponseData::Ppm(ppm::ResponseData::GetCapability(cap))
+            .encode_into_slice(&mut cap_bytes)
+            .unwrap();
+        assert_eq!(cap_bytes, CAPABILITY_MESSAGE_IN);
+
+        let mut cc = gcc::ResponseData::default();
+        cc.set_operation_mode(
+            *gcc::OperationModeFlags::default()
+                .set_drp(true)
+                .set_usb2(true)
+                .set_usb3(true),
+        )
+        .set_provider(true)
+        .set_consumer(true);
+        let mut cc_bytes = [0u8; 2];
+        ResponseData::Lpm(lpm::ResponseData::GetConnectorCapability(cc))
+            .encode_into_slice(&mut cc_bytes)
+            .unwrap();
+        assert_eq!(cc_bytes, CONNECTOR_CAPABILITY_MESSAGE_IN);
+
+        let mut partner = gcs::ConnectorPartnerFlags::from(0u8);
+        partner.set_usb(true);
+        let status = gcs::ResponseData {
+            status_change: gcs::ConnectorStatusChange::default(),
+            connect_status: true,
+            status: Some(gcs::ConnectedStatus {
+                power_op_mode: gcs::PowerOperationMode::UsbDefault,
+                power_direction: PowerRole::Sink,
+                partner_flags: partner,
+                partner_type: gcs::ConnectorPartnerType::DfpAttached,
+                rdo: None,
+                battery_charging_status: Some(gcs::BatteryChargingCapabilityStatus::NotCharging),
+                provider_caps_limited: None,
+                bcd_pd_version: None,
+            }),
+        };
+        let mut cs_bytes = [0u8; 11];
+        ResponseData::Lpm(lpm::ResponseData::GetConnectorStatus(status))
+            .encode_into_slice(&mut cs_bytes)
+            .unwrap();
+        assert_eq!(cs_bytes, CONNECTOR_STATUS_MESSAGE_IN);
+
+        assert_eq!(
+            u32::from(*LocalCci::new_cmd_complete().set_data_len(16)),
+            CCI_CAPABILITY
+        );
+        assert_eq!(
+            u32::from(*LocalCci::new_cmd_complete().set_data_len(2)),
+            CCI_CONNECTOR_CAPABILITY
+        );
+        assert_eq!(
+            u32::from(*LocalCci::new_cmd_complete().set_data_len(11)),
+            CCI_CONNECTOR_STATUS
+        );
+        assert_eq!(
+            u32::from(*LocalCci::default().set_not_supported(true)),
+            CCI_NOT_SUPPORTED
+        );
+    }
+}

--- a/platform/qemu-sp/linker/qemu-ec-sp.dts
+++ b/platform/qemu-sp/linker/qemu-ec-sp.dts
@@ -25,6 +25,7 @@
 	 * EC_SVC_POWER 		7157addf-2fbe-4c63-ae95-efac16e3b01c
 	 * EC_SVC_BATTERY 		25cb5207-ac36-427d-aaef-3aa78877d27e
 	 * EC_SVC_THERMAL		31f56da7-593c-4d72-a4b3-8fc7171ac073
+	 * EC_SVC_UCSI			65467f50-827f-4e4f-8770-dbf4c3f77f45
 	 * TPM2_SERVICE         17b862a4-1806-4faf-86b3-089a58353861
 	 */
 
@@ -37,6 +38,7 @@
 		   <0xdfad5771 0x634cbe2f 0xacef95ae 0x1cb0e316>,
 		   <0x0752cb25 0x7d4236ac 0xa73aefaa 0x7ed27788>,
 		   <0xa76df531 0x724d3c59 0xc78fb3a4 0x73c01a17>,
+		   <0x507f4665 0x4f4e7f82 0xf4db7087 0x457ff7c3>,
 		   <0xa462b817 0xaf4f0618 0x9a08b386 0x61383558>;
 	id = <0x8002>;
 	execution-ctx-count = <1>;

--- a/platform/qemu-sp/src/main.rs
+++ b/platform/qemu-sp/src/main.rs
@@ -38,6 +38,7 @@ fn main() -> ! {
 
     MessageHandler::new()
         .append(Thermal::new(&relay))
+        .append(ec_service_lib::services::Ucsi::new())
         .append(ec_service_lib::services::FwMgmt::new())
         .append(ec_service_lib::services::Notify::new())
         .append(battery::Battery::new())

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -37,6 +37,21 @@ criteria = "safe-to-deploy"
 version = "1.5.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.bincode]]
+version = "2.0.1"
+criteria = "safe-to-run"
+notes = "Host-test-only embedded-usb-pd wire-format oracle."
+
+[[exemptions.bitfield]]
+version = "0.19.5"
+criteria = "safe-to-run"
+notes = "Host-test-only embedded-usb-pd wire-format oracle."
+
+[[exemptions.bitfield-macros]]
+version = "0.19.5"
+criteria = "safe-to-run"
+notes = "Host-test-only embedded-usb-pd wire-format oracle."
+
 [[exemptions.bitflags]]
 version = "2.11.1"
 criteria = "safe-to-deploy"
@@ -164,6 +179,11 @@ criteria = "safe-to-deploy"
 version = "2.0.117"
 criteria = "safe-to-deploy"
 
+[[exemptions.syn]]
+version = "3.0.3"
+criteria = "safe-to-run"
+notes = "Host-test-only embedded-usb-pd wire-format oracle."
+
 [[exemptions.thiserror]]
 version = "2.0.18"
 criteria = "safe-to-deploy"
@@ -177,6 +197,11 @@ notes = "thiserror proc-macro transitive."
 [[exemptions.tock-registers]]
 version = "0.9.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.unty]]
+version = "0.0.4"
+criteria = "safe-to-run"
+notes = "Host-test-only embedded-usb-pd wire-format oracle."
 
 [[exemptions.uuid]]
 version = "1.17.0"


### PR DESCRIPTION
## Summary
- add a deterministic UCSI 1.2 FF-A service for the QEMU secure partition
- support capability, connector-capability, and connector-status reads for one fake connected sink
- register the service in the repository QEMU SP and advertise its UUID
- validate hand-encoded fixtures against current embedded-usb-pd in host-only tests

## Scope
The stub is synchronous and secure-world-only. It does not add EC relay, PD hardware, notifications, or native Windows UCSI class-driver integration.

## Validation
- full repository pre-commit checks
- cargo-deny and cargo-vet
- host tests and aarch64 SP builds
- fork CI green: https://github.com/dymk/odp-secure-services/pull/13

## Related
- documentation: https://github.com/OpenDevicePartnership/documentation/pull/89
- tracks https://github.com/OpenDevicePartnership/odp-platform-qemu-arm-virt/issues/41